### PR TITLE
Add HTTP_HOST/HTTP_PORT env vars; document all env var overrides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,10 +210,15 @@ The `info` response advertises both `asr` and `tts` arrays so Home Assistant kno
 **Config** (nested under `servers` in `speech-server.yaml`):
 ```yaml
 servers:
+  http:
+    host: 127.0.0.1   # default 127.0.0.1; override with HTTP_HOST env var or Vapor's --hostname flag
+    port: 8080        # default 8080; override with HTTP_PORT env var or Vapor's --port flag
   wyoming:
-    host: 127.0.0.1   # default 127.0.0.1; override with WYOMING_HOST env var
+    host: 127.0.0.1   # default 127.0.0.1; override with WYOMING_HOST env var (independent of http.host)
     port: 10300       # 0 = disabled; default 10300; override with WYOMING_PORT env var
 ```
+
+Both `http.host` and `wyoming.host` are independently configurable — they do not need to match.
 
 **Test files** (`Tests/speech-serverTests/`):
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ servers:
     port: 8080
     upload_limit_mb: 500
   wyoming:
-    host: 127.0.0.1       # should match http.host
+    host: 127.0.0.1       # can differ from http.host; set independently
     port: 10300           # TCP port for Wyoming protocol (Home Assistant). 0 = disabled.
 
 stt:
@@ -62,10 +62,20 @@ All fields are optional — omitted fields use the defaults shown above.
 ```bash
 # Use an explicit config file via env var
 SPEECH_SERVER_CONFIG=/etc/speech-server.yaml swift run speech-server
-
-# Vapor's --hostname and --port flags override config-file values
-swift run speech-server serve --hostname 192.168.1.50 --port 9090
 ```
+
+### Environment variable overrides
+
+Individual settings can also be overridden with environment variables:
+
+| Variable | Overrides | Example |
+|----------|-----------|---------|
+| `HTTP_HOST` | `servers.http.host` | `HTTP_HOST=192.168.1.50` |
+| `HTTP_PORT` | `servers.http.port` | `HTTP_PORT=9090` |
+| `WYOMING_HOST` | `servers.wyoming.host` | `WYOMING_HOST=192.168.1.50` |
+| `WYOMING_PORT` | `servers.wyoming.port` | `WYOMING_PORT=0` (disables Wyoming) |
+
+Vapor's `--hostname` and `--port` CLI flags also work and take highest priority for the HTTP server.
 
 ## API
 
@@ -155,14 +165,14 @@ The HTTP API is compatible with any app or library that supports a configurable 
 
 1. Open MacWhisper **Preferences**
 2. Go to the **Provider** tab and choose **Custom**
-3. Set the **API URL** to `http://<host>:8080/v1/audio/transcriptions`
+3. Set the **API URL** to `http://<host>:<port>/v1/audio/transcriptions` (default `localhost:8080`)
 4. Enter any string as the **API Key** (e.g. `local`)
 
 Audio is sent directly to the endpoint; transcription happens entirely on-device with no round-trip to the cloud.
 
 ### Other apps
 
-Any tool that supports a configurable OpenAI base URL should work out of the box: set the base URL to `http://<host>:8080` and use any string as the API key. This includes the official OpenAI Python and JavaScript SDKs, and similar tools.
+Any tool that supports a configurable OpenAI base URL should work out of the box: set the base URL to `http://<host>:<port>` (default `localhost:8080`) and use any string as the API key. This includes the official OpenAI Python and JavaScript SDKs, and similar tools.
 
 ## Accessing from other machines
 
@@ -212,7 +222,7 @@ A single TCP port (default `10300`) handles both STT and TTS -- Home Assistant d
 
 ### Network setup
 
-Home Assistant typically runs on a separate machine, so the Wyoming port must be reachable from it. See [Accessing from other machines](#accessing-from-other-machines) above for Tailscale and LAN options -- in either case, set `servers.http.host` and `servers.wyoming.host` to your Mac's specific IP so both ports are reachable from HA.
+Home Assistant typically runs on a separate machine, so the Wyoming port must be reachable from it. See [Accessing from other machines](#accessing-from-other-machines) above for Tailscale and LAN options -- in either case, set `servers.http.host` and `servers.wyoming.host` to your Mac's IP (or use the `HTTP_HOST` and `WYOMING_HOST` environment variables) so both ports are reachable from HA.
 
 ### Adding the Wyoming integration in Home Assistant
 

--- a/Sources/speech-server/configure.swift
+++ b/Sources/speech-server/configure.swift
@@ -14,9 +14,25 @@ func configure(_ app: Application) async throws {
         app.logger.warning("Unknown log_level '\(config.logLevel)'; defaulting to 'notice'.")
     }
 
-    // Apply host/port (Vapor's --hostname/--port CLI args override these after configure())
-    app.http.server.configuration.hostname = config.servers.http.host
-    app.http.server.configuration.port = config.servers.http.port
+    // Apply host/port from config, with env var and CLI overrides.
+    // Priority: HTTP_HOST/HTTP_PORT env vars > config file > built-in defaults.
+    // Vapor's --hostname/--port CLI args take highest priority and are applied after configure().
+    let httpHost: String
+    if let envHost = ProcessInfo.processInfo.environment["HTTP_HOST"] {
+        httpHost = envHost
+    }
+    else {
+        httpHost = config.servers.http.host
+    }
+    let httpPort: Int
+    if let envPort = ProcessInfo.processInfo.environment["HTTP_PORT"], let parsed = Int(envPort) {
+        httpPort = parsed
+    }
+    else {
+        httpPort = config.servers.http.port
+    }
+    app.http.server.configuration.hostname = httpHost
+    app.http.server.configuration.port = httpPort
 
     app.middleware = Middlewares()
     app.middleware.use(RequestLoggingMiddleware())

--- a/speech-server.yaml.example
+++ b/speech-server.yaml.example
@@ -12,12 +12,12 @@ log_level: notice     # trace | debug | info | notice | warning | error | critic
 
 servers:
   http:
-    host: 127.0.0.1       # Bind address. Use a LAN/Tailscale IP to accept connections from other devices.
-    port: 8080            # Listening port. Overridden by Vapor's --port CLI arg.
+    host: 127.0.0.1       # Bind address; override with HTTP_HOST env var or Vapor's --hostname flag.
+    port: 8080            # Listening port; override with HTTP_PORT env var or Vapor's --port flag.
     upload_limit_mb: 500  # Maximum multipart upload size for /audio/transcriptions
   wyoming:
-    host: 127.0.0.1       # Bind address for Wyoming TCP server (should match http.host).
-    port: 10300           # TCP port for Wyoming protocol (Home Assistant). 0 = disabled; default 10300.
+    host: 127.0.0.1       # Bind address for Wyoming TCP server; override with WYOMING_HOST env var.
+    port: 10300           # TCP port for Wyoming protocol (Home Assistant). 0 = disabled; override with WYOMING_PORT env var.
 
 stt:
   engine: parakeet      # Speech-to-text engine. Currently only: parakeet


### PR DESCRIPTION
## Summary

- Adds `HTTP_HOST` and `HTTP_PORT` environment variable overrides for the HTTP server, matching the existing `WYOMING_HOST`/`WYOMING_PORT` pattern — all four env vars now work symmetrically
- Removes the misleading "should match http.host" comment on `wyoming.host`; both hosts are independently configurable
- Adds an **Environment variable overrides** table to README (previously `WYOMING_HOST`/`WYOMING_PORT` were only documented in AGENTS.md)
- Fixes `<host>:8080` hardcoded-port placeholders to `<host>:<port>` with `(default localhost:8080)`
- Updates the HA network setup paragraph to mention env vars as an alternative to editing the YAML

Closes #3 (follow-up issue filed separately for unifying CLI args across HTTP and Wyoming).

## Test plan

- [ ] `swift build` passes (verified locally)
- [ ] `swift format lint --strict --recursive Sources/ Tests/` passes (verified locally)
- [ ] CI (swift-format + tests) passes on this PR
- [ ] Manual: `HTTP_HOST=0.0.0.0 HTTP_PORT=9090 swift run speech-server` binds HTTP to `0.0.0.0:9090`
- [ ] Manual: `WYOMING_HOST=0.0.0.0 swift run speech-server` binds Wyoming to `0.0.0.0:10300`

🤖 Generated with [Claude Code](https://claude.com/claude-code)