### PR TITLE
Upgrade FluidAudio to 0.12.1 (pin <0.12.2 until upstream SDK guard fix)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,8 @@ sent the status code cannot be changed to 4xx.
 
 The Wyoming server runs alongside the HTTP server on a single TCP port (default 10300). A single port serves both TTS and STT — the handler dispatches by incoming event type. Enabled by default; set `wyoming.port: 0` to disable.
 
+**Testing note**: `configure.swift` skips Wyoming registration when `app.environment == .testing`. This mirrors how Vapor skips the HTTP bind in test mode — Vapor's `.testing` environment only suppresses the HTTP server, not lifecycle handlers. Without this guard, integration tests would attempt a real TCP `bind()` and fail with `EADDRINUSE` if a production server is running on the same port.
+
 **Wire format** — each event has up to 3 parts:
 1. Header line: JSON + `\n`. Contains `type`, `version`, optionally `data_length` and `payload_length`.
 2. Data section (optional): exactly `data_length` bytes of UTF-8 JSON with the event's data dict.
@@ -266,6 +268,8 @@ Install with: `scripts/install-hooks.sh`
 
 **Important for agents**: always run `swift format --in-place --recursive Sources/ Tests/` before finishing any task that modifies Swift files. The CI check is strict and will fail the build if any file is not formatted.
 
+**Important for agents**: after formatting, always run `swift test` to confirm all tests pass before considering a task complete. Unit tests are fast; integration tests require model downloads on first run but are cached after that.
+
 **Snake_case CodingKeys**: `SpeechRequest` and `TranscriptionSegment` use explicit `CodingKeys` to map camelCase Swift properties to snake_case JSON fields (e.g. `responseFormat` → `"response_format"`). Do not revert to bare snake_case property names — the `AlwaysUseLowerCamelCase` lint rule will reject them.
 
 ## Build and run
@@ -293,7 +297,7 @@ swift test --filter ServerConfig  # run a specific test class
 
 | File | Type | Notes |
 |------|------|-------|
-| `Helpers/TestApp.swift` | Helper | `sharedTestApp()` singleton, multipart builder, word-overlap helper |
+| `Helpers/TestApp.swift` | Helper | `sharedTestApp()` singleton, multipart builder, word-overlap helper. Uses a temp `{}` YAML file to suppress local `speech-server.yaml`. Registers `AppShutdownObserver` (via `XCTestObservationCenter`) to call `app.asyncShutdown()` at bundle finish — required because `ServeCommand` has a `deinit` assertion that fires if its async shutdown was never called. |
 | `ServerConfigTests.swift` | Unit | YAML parsing, defaults — no models needed |
 | `AudioFormatDetectionTests.swift` | Unit | `audioFileExtension()` — no models needed |
 | `SpeechRequestTests.swift` | Unit | `SpeechRequest` resolved defaults — no models needed |

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "89eeed432b96c74bdf839990ae99ea59e5c61f65286e11f167aab6253585f26b",
+  "originHash" : "39201ccf3ceeb0d20d4f7d4eadbf86f9a3d57df824c85526a027c97ae94836c1",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "1cf23303df75df13e8dc92a0343c40006fbbe234",
-        "version" : "0.12.1"
+        "revision" : "92a550bdd0c6c3f8be70533f28284a2a15d3b71e",
+        "version" : "0.12.3"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "39201ccf3ceeb0d20d4f7d4eadbf86f9a3d57df824c85526a027c97ae94836c1",
+  "originHash" : "3baea2faf66320267e43c6afbdb278c8e9685402ea7f8e1df44ec4602a5056c8",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "92a550bdd0c6c3f8be70533f28284a2a15d3b71e",
-        "version" : "0.12.3"
+        "revision" : "1cf23303df75df13e8dc92a0343c40006fbbe234",
+        "version" : "0.12.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,10 @@ let package = Package(
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.76.0"),
-        .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.12.3"),
+        // FluidAudio 0.12.2+ uses MLMultiArrayDataType.int8 guarded by #if swift(>=6.2),
+        // but .int8 requires the macOS 26 SDK — breaks on macOS 15 CI runners.
+        // Pin to <0.12.2 until upstream fixes the guard. See: https://github.com/FluidInference/FluidAudio/issues/363
+        .package(url: "https://github.com/FluidInference/FluidAudio.git", "0.12.0"..<"0.12.2"),
         .package(url: "https://github.com/vapor/multipart-kit.git", from: "4.0.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "6.0.1"),
         // async-http-client 1.31+ depends on swift-configuration, which uses Data.bytes.

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.76.0"),
-        .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.7.9"),
+        .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.12.3"),
         .package(url: "https://github.com/vapor/multipart-kit.git", from: "4.0.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "6.0.1"),
         // async-http-client 1.31+ depends on swift-configuration, which uses Data.bytes.

--- a/Sources/speech-server/ServerConfig.swift
+++ b/Sources/speech-server/ServerConfig.swift
@@ -49,7 +49,7 @@ struct ServerConfig: Codable, Sendable {
         return .default
     }
 
-    private static func loadFromFile(path: String) throws -> ServerConfig {
+    static func loadFromFile(path: String) throws -> ServerConfig {
         let url = URL(fileURLWithPath: path)
         let contents = try String(contentsOf: url, encoding: .utf8)
         // An empty file (e.g. /dev/null) means "use all defaults".

--- a/Sources/speech-server/ServerConfig.swift
+++ b/Sources/speech-server/ServerConfig.swift
@@ -52,6 +52,10 @@ struct ServerConfig: Codable, Sendable {
     private static func loadFromFile(path: String) throws -> ServerConfig {
         let url = URL(fileURLWithPath: path)
         let contents = try String(contentsOf: url, encoding: .utf8)
+        // An empty file (e.g. /dev/null) means "use all defaults".
+        guard !contents.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return .default
+        }
         return try YAMLDecoder().decode(ServerConfig.self, from: contents)
     }
 }

--- a/Sources/speech-server/configure.swift
+++ b/Sources/speech-server/configure.swift
@@ -83,7 +83,7 @@ func configure(_ app: Application) async throws {
     else {
         wyomingPort = config.servers.wyoming.port
     }
-    if wyomingPort > 0 {
+    if wyomingPort > 0 && app.environment != .testing {
         let wyomingServer = WyomingServer(
             host: wyomingHost,
             port: wyomingPort,

--- a/Tests/speech-serverTests/Helpers/TestApp.swift
+++ b/Tests/speech-serverTests/Helpers/TestApp.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTVapor
+import XCTest
 
 @testable import speech_server
 
@@ -9,11 +10,38 @@ import XCTVapor
 // run; once cached on disk, initialization is fast but still non-trivial).
 // ---------------------------------------------------------------------------
 
+// Strong reference to the shutdown observer — XCTestObservationCenter holds observers weakly,
+// so without this the observer would be released immediately after registration.
+nonisolated(unsafe) private var _shutdownObserver: AppShutdownObserver?
+
 private let _appTask: Task<Application, Error> = Task {
     // Suppress the CWD speech-server.yaml so tests always use built-in defaults.
-    // (configure() calls ServerConfig.load() which finds the file in the package root)
+    // Write a minimal valid YAML file ({} = empty mapping → all fields use defaults)
+    // and point SPEECH_SERVER_CONFIG at it. Cannot use /dev/null — not readable in sandbox.
+    let tempConfig = FileManager.default.temporaryDirectory
+        .appendingPathComponent(
+            "speech-server-test-\(ProcessInfo.processInfo.processIdentifier).yaml")
+    try "{}\n".write(to: tempConfig, atomically: true, encoding: .utf8)
+    setenv("SPEECH_SERVER_CONFIG", tempConfig.path, 1)
     let app = try await Application.make(.testing)
-    try await configure(app)
+    do {
+        try await configure(app)
+    }
+    catch {
+        // If configure() throws, the app will be released without shutdown, triggering
+        // ServeCommand's deinit assertion. Explicitly shut it down first.
+        try? await app.asyncShutdown()
+        throw error
+    }
+    // Register shutdown observer so ServeCommand's deinit assertion is satisfied
+    // when the shared app is released at process exit. Must retain it ourselves because
+    // XCTestObservationCenter only holds a weak reference. Registration must happen
+    // on the main thread (XCTestObservationCenter requirement).
+    let observer = AppShutdownObserver()
+    _shutdownObserver = observer
+    await MainActor.run {
+        XCTestObservationCenter.shared.addTestObserver(observer)
+    }
     return app
 }
 
@@ -21,6 +49,25 @@ private let _appTask: Task<Application, Error> = Task {
 /// The app is initialized once; concurrent callers wait on the same Task.
 func sharedTestApp() async throws -> Application {
     try await _appTask.value
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle — call asyncShutdown() when the XCTest bundle finishes.
+// Application.make() registers a ServeCommand with a deinit assertion that
+// fires (SIGTRAP) if asyncShutdown() was not called before deinit.
+// ---------------------------------------------------------------------------
+
+private final class AppShutdownObserver: NSObject, XCTestObservation {
+    func testBundleDidFinish(_ testBundle: Bundle) {
+        let sema = DispatchSemaphore(value: 0)
+        Task.detached {
+            if let app = try? await _appTask.value {
+                try? await app.asyncShutdown()
+            }
+            sema.signal()
+        }
+        sema.wait()
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/Tests/speech-serverTests/RoundTripIntegrationTests.swift
+++ b/Tests/speech-serverTests/RoundTripIntegrationTests.swift
@@ -16,8 +16,6 @@ final class RoundTripIntegrationTests: XCTestCase {
         app = try await sharedTestApp()
     }
 
-    override func tearDown() async throws {}
-
     // MARK: - Round-trip test
 
     func testRoundTripMultiSentence() async throws {

--- a/Tests/speech-serverTests/SentenceDetectionTests.swift
+++ b/Tests/speech-serverTests/SentenceDetectionTests.swift
@@ -20,6 +20,31 @@ final class SentenceDetectionTests: XCTestCase {
         XCTAssertEqual(result, ["Hello world."])
     }
 
+    func testDetectSentencesQuestionMark() {
+        XCTAssertEqual(detectSentences("Who are you?"), ["Who are you?"])
+    }
+
+    func testDetectSentencesExclamation() {
+        XCTAssertEqual(detectSentences("Watch out!"), ["Watch out!"])
+    }
+
+    func testDetectSentencesThreeSentences() {
+        let result = detectSentences("One. Two! Three?")
+        XCTAssertEqual(result, ["One.", "Two!", "Three?"])
+    }
+
+    func testDetectSentencesWhitespaceOnly() {
+        // Whitespace-only input should produce a single sentence with a period appended
+        // (the impl normalises and returns a non-empty result rather than crashing)
+        let result = detectSentences("   ")
+        XCTAssertFalse(result.isEmpty)
+    }
+
+    func testDetectSentencesEmptyString() {
+        // Empty string: either empty array or a single empty-ish sentence — must not crash
+        XCTAssertNoThrow(detectSentences(""))
+    }
+
     // MARK: - splitCompleteSentences
 
     func testSplitCompleteSentencesWithRemainder() {

--- a/Tests/speech-serverTests/ServerConfigTests.swift
+++ b/Tests/speech-serverTests/ServerConfigTests.swift
@@ -137,6 +137,20 @@ final class ServerConfigTests: XCTestCase {
         XCTAssertEqual(config.tts.engine, .pocketTts)
     }
 
+    func testEmptyFileProducesAllDefaults() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("empty-config-test-\(ProcessInfo.processInfo.processIdentifier).yaml")
+        try "".write(to: tmp, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let config = try ServerConfig.loadFromFile(path: tmp.path)
+        XCTAssertEqual(config.servers.http.host, "127.0.0.1")
+        XCTAssertEqual(config.servers.http.port, 8080)
+        XCTAssertEqual(config.logLevel, "notice")
+        XCTAssertEqual(config.stt.engine, .parakeet)
+        XCTAssertEqual(config.tts.engine, .pocketTts)
+    }
+
     func testHTTPSubsectionOnly() throws {
         let yaml = """
             servers:

--- a/Tests/speech-serverTests/SpeechIntegrationTests.swift
+++ b/Tests/speech-serverTests/SpeechIntegrationTests.swift
@@ -10,8 +10,6 @@ final class SpeechIntegrationTests: XCTestCase {
         app = try await sharedTestApp()
     }
 
-    override func tearDown() async throws {}
-
     // MARK: - Request helpers
 
     private func postSpeech(

--- a/Tests/speech-serverTests/TranscriptionIntegrationTests.swift
+++ b/Tests/speech-serverTests/TranscriptionIntegrationTests.swift
@@ -11,9 +11,6 @@ final class TranscriptionIntegrationTests: XCTestCase {
         app = try await sharedTestApp()
     }
 
-    // Don't shut the app down here — it's shared across test classes.
-    override func tearDown() async throws {}
-
     // MARK: - Fixture helpers
 
     private func fixture(_ name: String, _ ext: String) throws -> Data {

--- a/Tests/speech-serverTests/WyomingSessionTests.swift
+++ b/Tests/speech-serverTests/WyomingSessionTests.swift
@@ -3,13 +3,19 @@ import XCTest
 @testable import speech_server
 
 final class WyomingSessionTests: XCTestCase {
-    // MARK: - Helper
+    // MARK: - Helpers
 
     /// Collects all values from an AsyncStream into an array.
     private func collect(_ stream: AsyncStream<Data>) async -> [Data] {
         var results: [Data] = []
         for await data in stream { results.append(data) }
         return results
+    }
+
+    /// Concatenates response chunks and decodes them as Wyoming events.
+    private func decodeEvents(from responses: [Data]) -> [WyomingEvent] {
+        var decoder = WyomingFrameDecoder()
+        return decoder.process(responses.reduce(Data(), +))
     }
 
     // MARK: - describe → info
@@ -23,9 +29,7 @@ final class WyomingSessionTests: XCTestCase {
         let responses = await collect(stream)
         XCTAssertEqual(responses.count, 1)
 
-        // Decode the response event
-        var decoder = WyomingFrameDecoder()
-        let events = decoder.process(responses[0])
+        let events = decodeEvents(from: responses)
         XCTAssertEqual(events.count, 1)
         XCTAssertEqual(events[0].type, "info")
     }
@@ -37,8 +41,7 @@ final class WyomingSessionTests: XCTestCase {
         )
         let stream = await session.handle(event: WyomingEvent(type: "describe"))
         let responses = await collect(stream)
-        var decoder = WyomingFrameDecoder()
-        let events = decoder.process(responses[0])
+        let events = decodeEvents(from: responses)
         let info = events[0]
 
         // Must have both asr and tts arrays
@@ -124,11 +127,7 @@ final class WyomingSessionTests: XCTestCase {
             ))
         let responses = await collect(stream)
 
-        // Decode all response events
-        var decoder = WyomingFrameDecoder()
-        var allData = Data()
-        for r in responses { allData.append(r) }
-        let events = decoder.process(allData)
+        let events = decodeEvents(from: responses)
 
         // Expect: audio-start, audio-chunk (×1), audio-stop
         XCTAssertEqual(events.count, 3)
@@ -159,11 +158,7 @@ final class WyomingSessionTests: XCTestCase {
                 data: ["text": .string("Two sentences. Here is one more.")]
             ))
         let responses = await collect(stream)
-
-        var decoder = WyomingFrameDecoder()
-        var allData = Data()
-        for r in responses { allData.append(r) }
-        let events = decoder.process(allData)
+        let events = decodeEvents(from: responses)
 
         // audio-start + 2×audio-chunk + audio-stop = 4 events
         XCTAssertEqual(events.count, 4)
@@ -294,8 +289,7 @@ final class WyomingSessionTests: XCTestCase {
         let r4 = await collect(stream4)
         XCTAssertEqual(r4.count, 1)
 
-        var decoder = WyomingFrameDecoder()
-        let events = decoder.process(r4[0])
+        let events = decodeEvents(from: r4)
         XCTAssertEqual(events.count, 1)
         XCTAssertEqual(events[0].type, "transcript")
         XCTAssertEqual(events[0].data["text"]?.stringValue, "hello world")
@@ -392,8 +386,7 @@ final class WyomingSessionTests: XCTestCase {
         )
         let stream = await session.handle(event: WyomingEvent(type: "describe"))
         let responses = await collect(stream)
-        var decoder = WyomingFrameDecoder()
-        let events = decoder.process(responses[0])
+        let events = decodeEvents(from: responses)
         let info = events[0]
 
         let ttsArray = info.data["tts"]?.arrayValue
@@ -430,10 +423,7 @@ final class WyomingSessionTests: XCTestCase {
         // synthesize-stop with empty buffer → only synthesize-stopped
         let r3 = await collect(await session.handle(event: WyomingEvent(type: "synthesize-stop")))
 
-        var decoder = WyomingFrameDecoder()
-        var allData = Data()
-        for d in r2 + r3 { allData.append(d) }
-        let events = decoder.process(allData)
+        let events = decodeEvents(from: r2 + r3)
 
         // audio-start, audio-chunk, audio-stop, synthesize-stopped
         XCTAssertEqual(events.count, 4)
@@ -476,10 +466,7 @@ final class WyomingSessionTests: XCTestCase {
 
         let r4 = await collect(await session.handle(event: WyomingEvent(type: "synthesize-stop")))
 
-        var decoder = WyomingFrameDecoder()
-        var allData = Data()
-        for d in r2 + r3 + r4 { allData.append(d) }
-        let events = decoder.process(allData)
+        let events = decodeEvents(from: r2 + r3 + r4)
 
         // Two complete audio sequences + synthesize-stopped
         let types = events.map { $0.type }
@@ -517,10 +504,7 @@ final class WyomingSessionTests: XCTestCase {
         // synthesize-stop: remaining "This is" should be synthesized
         let r3 = await collect(await session.handle(event: WyomingEvent(type: "synthesize-stop")))
 
-        var decoder = WyomingFrameDecoder()
-        var allData = Data()
-        for d in r2 + r3 { allData.append(d) }
-        let events = decoder.process(allData)
+        let events = decodeEvents(from: r2 + r3)
 
         // "Hello world." synthesized from chunk, "This is." synthesized at stop
         let types = events.map { $0.type }
@@ -564,10 +548,7 @@ final class WyomingSessionTests: XCTestCase {
 
         // synthesize-stop should still finalise the streaming session
         let rStop = await collect(await session.handle(event: WyomingEvent(type: "synthesize-stop")))
-        var decoder = WyomingFrameDecoder()
-        var allData = Data()
-        for d in rStop { allData.append(d) }
-        let events = decoder.process(allData)
+        let events = decodeEvents(from: rStop)
         XCTAssertTrue(events.contains(where: { $0.type == "synthesize-stopped" }))
     }
 
@@ -587,10 +568,7 @@ final class WyomingSessionTests: XCTestCase {
         // synthesize-stop with no chunks → only synthesize-stopped, no audio
         let responses = await collect(await session.handle(event: WyomingEvent(type: "synthesize-stop")))
 
-        var decoder = WyomingFrameDecoder()
-        var allData = Data()
-        for d in responses { allData.append(d) }
-        let events = decoder.process(allData)
+        let events = decodeEvents(from: responses)
 
         XCTAssertEqual(events.count, 1)
         XCTAssertEqual(events[0].type, "synthesize-stopped")
@@ -618,10 +596,7 @@ final class WyomingSessionTests: XCTestCase {
 
         let rStop = await collect(await session.handle(event: WyomingEvent(type: "synthesize-stop")))
 
-        var decoder = WyomingFrameDecoder()
-        var allData = Data()
-        for d in rChunk + rStop { allData.append(d) }
-        let events = decoder.process(allData)
+        let events = decodeEvents(from: rChunk + rStop)
 
         // No audio chunks since TTS failed, but synthesize-stopped must still arrive
         XCTAssertFalse(events.contains(where: { $0.type == "audio-chunk" }))
@@ -673,8 +648,7 @@ final class WyomingSessionTests: XCTestCase {
         let stream = await session.handle(event: WyomingEvent(type: "describe"))
         let infoResponses = await collect(stream)
         XCTAssertEqual(infoResponses.count, 1)
-        var decoder = WyomingFrameDecoder()
-        let events = decoder.process(infoResponses[0])
+        let events = decodeEvents(from: infoResponses)
         XCTAssertEqual(events[0].type, "info")
     }
 }


### PR DESCRIPTION
## Summary

- Bumps the `FluidAudio` minimum version constraint in `Package.swift` from `0.7.9` to `0.12.0`..<`0.12.2`, resolving to **0.12.1**
- Pins below 0.12.2 to avoid a build regression introduced in that release (see below)
- Updates `Package.resolved` accordingly

No API changes were required — all types used by `FluidSTTService` and `FluidTTSService` (`AsrManager`, `VadManager`, `PocketTtsManager`, `DiskBackedAudioSampleSource`, etc.) are unchanged.

Notable upstream improvements included in this range (0.7.9 → 0.12.1):
- **0.12.0**: New PocketTTS model with EOS detection and real-time support
- **0.11.0**: Custom vocabulary support
- **0.10.0**: Sortformer real-time speaker diarization
- **0.9.0**: Swift 6 concurrency support

### Why not 0.12.2 or 0.12.3?

FluidAudio 0.12.2 introduced `KokoroSynthesizer+Memory.swift`, which uses `MLMultiArrayDataType.int8` guarded by `#if swift(>=6.2)`. The `.int8` case requires the **macOS 26 SDK** — not just Swift 6.2. On `macos-15` CI runners (macOS 15 SDK, Swift 6.2) the guard passes but the build fails:

```
error: type 'MLMultiArrayDataType' has no member 'int8'
```

This is the same class of bug fixed previously in `SortformerModelInference.swift` (commit 01479c75, closes #284), where a compile-time architecture guard was needed because a runtime `#available` check was insufficient for the compiler.

Reported upstream: **FluidInference/FluidAudio#363**. The pin will be lifted once a fixed release is available.

### Test infrastructure fixes (also in this PR)

Diagnosing why `testRoundTripMultiSentence` was failing uncovered three separate bugs in the test setup, all fixed here:

1. **Wyoming TCP bind in `.testing` mode** — `configure.swift` now skips registering the `WyomingServer` lifecycle handler when `app.environment == .testing`. Vapor's `.testing` mode only suppresses the HTTP bind, not lifecycle handlers, so without this guard integration tests would attempt a real `bind()` and hit `EADDRINUSE` if a production server is running on the same port.

2. **Local config suppression** — `TestApp.swift` now writes a minimal `{}` YAML temp file and points `SPEECH_SERVER_CONFIG` at it, ensuring tests always run with built-in config defaults regardless of any local `speech-server.yaml`. (`/dev/null` was tried first but is unreadable in the test sandbox.) `ServerConfig.loadFromFile` also gained an empty-content guard that returns `.default` for zero-length files.

3. **`ServeCommand` deinit assertion (SIGTRAP at process exit)** — `Application.make()` registers `ServeCommand` with an async-only shutdown closure. When the app deinits it calls the sync `shutdown()`, which skips async closures, so `ServeCommand.deinit` fires `assert(didShutdown)`. Fixed via `AppShutdownObserver` (`XCTestObservation`) that calls `app.asyncShutdown()` when the test bundle finishes. `XCTestObservationCenter` holds observers weakly, so a module-level `nonisolated(unsafe) var` keeps the observer alive.

### Test cleanup (also in this PR)

- Removed empty `tearDown()` overrides from the three integration test classes
- Extracted `decodeEvents(from:)` helper in `WyomingSessionTests` to replace a 4-line boilerplate pattern that appeared 12 times
- Added `testEmptyFileProducesAllDefaults` to `ServerConfigTests` (covers the new empty-content guard); `loadFromFile` made package-internal for testability
- Added 5 edge-case tests to `SentenceDetectionTests` (question mark, exclamation, three-sentence mix, whitespace-only, empty string)

## Test plan

- [x] `swift build --build-tests` — clean build, no warnings from our code
- [x] `swift test` — all tests pass, including `testRoundTripMultiSentence`, with a production server running on port 10300

🤖 Generated with [Claude Code](https://claude.com/claude-code)