### PR TITLE
Add Kokoro TTS engine (50 voices, 8 languages, 24 kHz)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,7 @@ jobs:
           path: |
             .build
             ~/Library/Application Support/FluidAudio
+            ~/.cache/fluidaudio
           key: ${{ runner.os }}-spm-${{ hashFiles('Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-spm-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,14 +7,14 @@ Essential knowledge for AI agents working on this codebase.
 A macOS-native HTTP server that exposes OpenAI-compatible speech API endpoints and a Wyoming protocol server for Home Assistant integration, running entirely on-device. Built with Vapor (Swift web framework) and FluidAudio (on-device ASR via Apple's Neural Engine).
 
 - **STT** is fully implemented using FluidAudio's `AsrManager`.
-- **TTS** is fully implemented using FluidAudio's `PocketTtsManager`. Only the `alba` voice is available; requesting any other voice returns a 400.
+- **TTS** is fully implemented with three engines: `pocket_tts` (FluidAudio PocketTTS, `alba` only), `avspeech` (macOS built-in, 150+ voices), and `kokoro` (FluidAudio Kokoro, 50 voices across 8 languages).
 
 ## Tech stack
 
 | Component | Library | Version constraint |
 |-----------|---------|-------------------|
 | Web framework | [Vapor](https://github.com/vapor/vapor) | 4.76.0+ |
-| Speech-to-text | [FluidAudio](https://github.com/FluidInference/FluidAudio) | 0.7.9+ |
+| Speech-to-text / TTS | [FluidAudio](https://github.com/FluidInference/FluidAudio) | 0.12.4+ |
 | Multipart parsing | [multipart-kit](https://github.com/vapor/multipart-kit) | 4.0.0+ |
 | YAML parsing | [Yams](https://github.com/jpsim/Yams) | 6.0.1+ |
 | TCP networking | [swift-nio](https://github.com/apple/swift-nio) | 2.65.0+ |
@@ -64,7 +64,7 @@ ServerConfig
   │   ├─ http: HTTPConfig          (host, port, uploadLimitMB)
   │   └─ wyoming: WyomingConfig    (host, port)
   ├─ stt: STTConfig                (engine, parakeet settings)
-  └─ tts: TTSConfig                (engine, pocket_tts settings)
+  └─ tts: TTSConfig                (engine, pocket_tts/avspeech/kokoro settings)
 ```
 
 Access: `config.logLevel`, `config.servers.http.host`, `config.servers.wyoming.port`.
@@ -205,9 +205,25 @@ support requires `requestPersonalVoiceAuthorization` and is tracked in issue #13
 cannot be resolved via lookup. `AVSpeechTTSError.noAudioProduced` is thrown if the synthesiser
 delivers zero samples (e.g. empty utterance after preprocessing).
 
+### KokoroTTSService
+
+`KokoroTTSService` wraps FluidAudio's `KokoroTtsManager` (50 voices, 8 languages, 24 kHz):
+
+1. On init (`initialize(settings:)`): creates `KokoroTtsManager(defaultVoice:)`, calls `manager.initialize()` (downloads Kokoro CoreML models on first run, cached at `~/.cache/fluidaudio/Models/kokoro`), sets `defaultVoice` from settings or `TtsConstants.recommendedVoice` (`"af_heart"`).
+2. On synthesize (`synthesize`): validates voice against `availableVoices`, calls `manager.synthesize()` which returns WAV data directly (no manual PCM conversion needed).
+3. On streaming (`synthesizeStream`): validates voice first (returns stream that immediately throws on invalid voice), splits text into sentences with `detectSentences()`, calls `manager.synthesizeDetailed()` per sentence, collects all samples from `result.chunks.flatMap { $0.samples }`, converts via `float32ToPCM16()`, yields one PCM chunk per sentence.
+4. Must call `initialize()` before first use — will throw `KokoroTTSError.notInitialized` otherwise.
+5. `@unchecked Sendable` because `KokoroTtsManager` is not `Sendable`. All stored properties besides the manager are immutable.
+
+**Voice list**: `TtsConstants.availableVoices` (50 voices, sorted alphabetically in `availableVoices` property). American English voices (`af_*`, `am_*`) are production quality; other languages are experimental.
+
+**`manager.synthesize()` returns WAV directly**: unlike PocketTTS which returns raw samples via `synthesizeDetailed().samples`, `KokoroTtsManager.synthesize()` returns a complete WAV `Data`. For streaming, `synthesizeDetailed()` returns a `KokoroSynthesizer.SynthesisResult` with `chunks: [ChunkInfo]`, each with `samples: [Float]`.
+
+**Errors**: `KokoroTTSError.notInitialized` and `KokoroTTSError.voiceNotFound(String)`.
+
 ### PCMConversion utilities
 
-`PCMConversion.swift` provides two package-internal free functions shared by both TTS services:
+`PCMConversion.swift` provides two package-internal free functions shared by all TTS services:
 
 - `float32ToPCM16(_ samples: [Float]) -> Data` — peak-normalises the sample batch (or uses
   1.0 if all samples are silent) and converts to little-endian Int16 PCM bytes.
@@ -219,8 +235,8 @@ delivers zero samples (e.g. empty utterance after preprocessing).
 The protocol (`TTSService.swift`) now includes three additional requirements read by controllers:
 
 ```swift
-var sampleRate: Int { get }        // e.g. 24_000 (FluidTTS) or 22_050 (AVSpeech)
-var defaultVoice: String { get }   // e.g. "alba" or "Samantha"
+var sampleRate: Int { get }        // e.g. 24_000 (FluidTTS/Kokoro) or 22_050 (AVSpeech)
+var defaultVoice: String { get }   // e.g. "alba", "Samantha", or "af_heart"
 var availableVoices: [String] { get } // sorted list of short names
 ```
 
@@ -295,6 +311,8 @@ Both `http.host` and `wyoming.host` are independently configurable — they do n
 | `AVSpeechConfigTests.swift` | YAML parsing for `avspeech` engine and `AVSpeechSettings` | No |
 | `PCMConversionTests.swift` | `float32ToPCM16` and `makeWAV` utilities | No |
 | `AVSpeechTTSServiceTests.swift` | Real `AVSpeechTTSService` (uses macOS system voices) | No |
+| `KokoroConfigTests.swift` | YAML parsing for `kokoro` engine and `KokoroSettings` | No |
+| `KokoroTTSServiceTests.swift` | Real `KokoroTTSService` (Kokoro CoreML models) | Yes |
 | `Helpers/MockServices.swift` | `MockTTSService` + `MockSTTService` for session tests | No |
 
 ### Error handling
@@ -376,6 +394,8 @@ swift test --filter ServerConfig  # run a specific test class
 | `AVSpeechConfigTests.swift` | Unit | YAML parsing for `avspeech` engine and `AVSpeechSettings` — no models needed |
 | `PCMConversionTests.swift` | Unit | `float32ToPCM16` and `makeWAV` — no models needed |
 | `AVSpeechTTSServiceTests.swift` | Unit | Real `AVSpeechTTSService` using macOS system voices — no models needed |
+| `KokoroConfigTests.swift` | Unit | YAML parsing for `kokoro` engine and `KokoroSettings` — no models needed |
+| `KokoroTTSServiceTests.swift` | Integration | Real `KokoroTTSService` with Kokoro CoreML models |
 | `Helpers/MockServices.swift` | Helper | MockTTSService + MockSTTService |
 
 **First run**: integration tests load real FluidAudio models (STT + TTS). Model download takes several minutes; subsequent runs use the on-disk cache and start in seconds. The shared app singleton (`_appTask` in `TestApp.swift`) ensures models are initialized once per `swift test` invocation.
@@ -387,7 +407,7 @@ swift test --filter ServerConfig  # run a specific test class
 `.github/workflows/tests.yml` runs on every push and PR to `main`.
 
 - **Runner**: `macos-15` with Swift 6.2 installed via `swift-actions/setup-swift@v2`.
-- **Cache**: `.build` and `~/Library/Application Support/FluidAudio` (all model subdirectories) are cached by `actions/cache@v4` keyed on `Package.resolved`. A `restore-keys` fallback allows partial hits (models survive SPM-only changes).
+- **Cache**: `.build`, `~/Library/Application Support/FluidAudio` (PocketTTS/ASR models), and `~/.cache/fluidaudio` (Kokoro models) are cached by `actions/cache@v4` keyed on `Package.resolved`. A `restore-keys` fallback allows partial hits (models survive SPM-only changes).
 - **Steps**: checkout → setup Swift → restore cache → `swift build --build-tests` → `swift test` (30 min timeout).
 - **Concurrency**: redundant runs on rapid pushes are cancelled via `concurrency.cancel-in-progress: true`.
 - **Cold-cache run**: model download + SPM compilation takes ~10-20 min. Warm-cache run: ~1-2 min.

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3baea2faf66320267e43c6afbdb278c8e9685402ea7f8e1df44ec4602a5056c8",
+  "originHash" : "00c2196a216d4f37501c0fa782e581fd6278ea4140a973bb37afb4f33acbe7da",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -29,12 +29,21 @@
       }
     },
     {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/EventSource.git",
+      "state" : {
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
+      }
+    },
+    {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "1cf23303df75df13e8dc92a0343c40006fbbe234",
-        "version" : "0.12.1"
+        "revision" : "2d2979486bd7125558fe783741ef9a2757b3c1bb",
+        "version" : "0.12.5"
       }
     },
     {
@@ -143,6 +152,15 @@
       "state" : {
         "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
         "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-huggingface",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-huggingface.git",
+      "state" : {
+        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
+        "version" : "0.9.0"
       }
     },
     {
@@ -258,8 +276,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers",
       "state" : {
-        "revision" : "3aecdf18e62303fb5a5543f8e87502b13474573f",
-        "version" : "1.1.7"
+        "revision" : "eed7264ac5e4ec5dfa6165c6e5c5577364344fe4",
+        "version" : "1.2.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -7,10 +7,10 @@ let package = Package(
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.76.0"),
-        // FluidAudio 0.12.2+ uses MLMultiArrayDataType.int8 guarded by #if swift(>=6.2),
-        // but .int8 requires the macOS 26 SDK — breaks on macOS 15 CI runners.
-        // Pin to <0.12.2 until upstream fixes the guard. See: https://github.com/FluidInference/FluidAudio/issues/363
-        .package(url: "https://github.com/FluidInference/FluidAudio.git", "0.12.0"..<"0.12.2"),
+        // FluidAudio 0.12.3 introduced KokoroTtsManager (Kokoro TTS engine).
+        // The .int8 SDK guard bug (issue #363) is fixed in v0.12.4 via #if canImport(FoundationModels).
+        // Require v0.12.4+ so CI on macOS 15 works and Kokoro TTS is available.
+        .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.12.4"),
         .package(url: "https://github.com/vapor/multipart-kit.git", from: "4.0.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "6.0.1"),
         // async-http-client 1.31+ depends on swift-configuration, which uses Data.bytes.

--- a/README.md
+++ b/README.md
@@ -48,24 +48,29 @@ stt:
     model_version: v3   # v3 = multilingual (25 langs, default), v2 = English-only
 
 tts:
-  engine: pocket_tts    # pocket_tts (default) | avspeech
+  engine: pocket_tts    # pocket_tts (default) | avspeech | kokoro
 
   # AVSpeech settings (only used when engine: avspeech)
   # avspeech:
   #   default_voice: Samantha   # Short name or full identifier; nil = system locale default
   #   sample_rate: 22050        # Native AVSpeech output rate (Hz)
+
+  # Kokoro TTS settings (only used when engine: kokoro)
+  # kokoro:
+  #   default_voice: af_heart   # Any Kokoro voice ID (e.g. af_heart, am_adam); default af_heart
 ```
 
 All fields are optional — omitted fields use the defaults shown above.
 
 ### TTS engines
 
-Two TTS engines are available:
+Three TTS engines are available:
 
-| Engine | `engine:` value | Voices | Downloads | Notes |
-|--------|----------------|--------|-----------|-------|
-| FluidAudio PocketTTS | `pocket_tts` | `alba` only | ~200 MB on first start | Default |
-| macOS AVSpeech | `avspeech` | 150+ system voices | None (ships with macOS) | Instant startup |
+| Engine | `engine:` value | Voices | Sample rate | Downloads | Notes |
+|--------|----------------|--------|-------------|-----------|-------|
+| FluidAudio PocketTTS | `pocket_tts` | `alba` only | 24 kHz | ~200 MB on first start | Default |
+| macOS AVSpeech | `avspeech` | 150+ system voices | 22050 Hz | None (ships with macOS) | Instant startup |
+| FluidAudio Kokoro | `kokoro` | 50 voices, 8 languages | 24 kHz | ~300 MB on first start | High quality |
 
 #### `pocket_tts` (default)
 
@@ -92,6 +97,21 @@ The short name (e.g. `Samantha`, `Daniel`, `Karen`) is used in API requests. Voi
 
 > **Note:** Siri voices are not accessible via public AVFoundation APIs and will not appear in the voice list.
 > Personal Voice support (macOS 14+) is planned — see issue #13.
+
+#### `kokoro` — FluidAudio Kokoro
+
+Uses [FluidAudio](https://github.com/FluidInference/FluidAudio)'s Kokoro CoreML model. 50 voices across 8 languages (American English, British English, Spanish, French, Hindi, Italian, Japanese, Brazilian Portuguese, Mandarin Chinese), synthesised at 24 kHz. Models are downloaded on first start and cached at `~/.cache/fluidaudio/Models/kokoro`.
+
+```yaml
+tts:
+  engine: kokoro
+  kokoro:
+    default_voice: af_heart   # Optional — default is af_heart (American English female)
+```
+
+American English voices (production-quality): `af_alloy`, `af_aoede`, `af_bella`, `af_heart`, `af_jessica`, `af_kore`, `af_nicole`, `af_nova`, `af_river`, `af_sarah`, `af_sky`, `am_adam`, `am_echo`, `am_eric`, `am_fenrir`, `am_liam`, `am_michael`, `am_onyx`, `am_puck`, `am_santa`.
+
+Other language voices are experimental (not QA'd). Full voice list: use `/v1/audio/speech` with an invalid voice to see the available options listed in the error message, or query `GET /v1/models` via your client library.
 
 ### Config discovery order
 
@@ -297,7 +317,7 @@ Content-Type: application/json
 | `response_format` | String | No       | `wav` (default) or `pcm`                           |
 | `speed`           | Double | No       | Playback speed, 0.25-4.0 (default: 1.0)           |
 
-The response is **streamed**: audio begins arriving before synthesis is complete, sentence by sentence. WAV responses include a standard 44-byte header (with unknown-size placeholders) followed by 16-bit PCM; PCM responses are raw 16-bit bytes. The sample rate depends on the active TTS engine (24 kHz for `pocket_tts`, 22050 Hz for `avspeech`).
+The response is **streamed**: audio begins arriving before synthesis is complete, sentence by sentence. WAV responses include a standard 44-byte header (with unknown-size placeholders) followed by 16-bit PCM; PCM responses are raw 16-bit bytes. The sample rate depends on the active TTS engine (24 kHz for `pocket_tts` and `kokoro`, 22050 Hz for `avspeech`).
 
 Example:
 
@@ -421,6 +441,7 @@ Sources/speech-server/
     TTSService.swift               # TTS protocol + DI
     FluidTTSService.swift          # FluidAudio PocketTTS implementation (pocket_tts engine)
     AVSpeechTTSService.swift       # macOS AVSpeechSynthesizer implementation (avspeech engine)
+    KokoroTTSService.swift         # FluidAudio Kokoro implementation (kokoro engine)
     PCMConversion.swift            # Shared Float32→Int16 PCM conversion and WAV builder
     SentenceDetection.swift        # Shared sentence splitting for TTS
   Middleware/

--- a/Sources/speech-server/ServerConfig.swift
+++ b/Sources/speech-server/ServerConfig.swift
@@ -160,11 +160,13 @@ struct TTSConfig: Codable, Sendable {
     var engine: TTSEngine
     var pocketTts: PocketTtsSettings?
     var avspeech: AVSpeechSettings?
+    var kokoro: KokoroSettings?
 
     init() {
         engine = .pocketTts
         pocketTts = nil
         avspeech = nil
+        kokoro = nil
     }
 
     init(from decoder: any Decoder) throws {
@@ -172,18 +174,21 @@ struct TTSConfig: Codable, Sendable {
         engine = try c.decodeIfPresent(TTSEngine.self, forKey: .engine) ?? .pocketTts
         pocketTts = try c.decodeIfPresent(PocketTtsSettings.self, forKey: .pocketTts)
         avspeech = try c.decodeIfPresent(AVSpeechSettings.self, forKey: .avspeech)
+        kokoro = try c.decodeIfPresent(KokoroSettings.self, forKey: .kokoro)
     }
 
     enum CodingKeys: String, CodingKey {
         case engine
         case pocketTts = "pocket_tts"
         case avspeech = "avspeech"
+        case kokoro = "kokoro"
     }
 }
 
 enum TTSEngine: String, Codable, Sendable {
     case pocketTts = "pocket_tts"
     case avspeech = "avspeech"
+    case kokoro = "kokoro"
 }
 
 struct PocketTtsSettings: Codable, Sendable {
@@ -225,6 +230,25 @@ struct AVSpeechSettings: Codable, Sendable {
     enum CodingKeys: String, CodingKey {
         case defaultVoice = "default_voice"
         case sampleRate = "sample_rate"
+    }
+}
+
+struct KokoroSettings: Codable, Sendable {
+    /// Default voice identifier for Kokoro synthesis.
+    /// Nil = use the FluidAudio recommended voice ("af_heart").
+    var defaultVoice: String?
+
+    init() {
+        defaultVoice = nil
+    }
+
+    init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        defaultVoice = try c.decodeIfPresent(String.self, forKey: .defaultVoice)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case defaultVoice = "default_voice"
     }
 }
 

--- a/Sources/speech-server/Services/KokoroTTSService.swift
+++ b/Sources/speech-server/Services/KokoroTTSService.swift
@@ -1,0 +1,90 @@
+import FluidAudio
+import Foundation
+import Logging
+
+final class KokoroTTSService: TTSService, @unchecked Sendable {
+    let sampleRate: Int = TtsConstants.audioSampleRate
+    private(set) var defaultVoice: String = TtsConstants.recommendedVoice
+    let availableVoices: [String] = TtsConstants.availableVoices.sorted()
+
+    private var manager: KokoroTtsManager?
+    private var logger: Logger = {
+        var l = Logger(label: "KokoroTTSService")
+        l.logLevel = .notice
+        return l
+    }()
+
+    func initialize(settings: KokoroSettings = KokoroSettings()) async throws {
+        let voiceId = settings.defaultVoice ?? TtsConstants.recommendedVoice
+        let m = KokoroTtsManager(defaultVoice: voiceId)
+        try await m.initialize()
+        self.manager = m
+        self.defaultVoice = voiceId
+    }
+
+    // Returns a complete WAV file produced directly by KokoroTtsManager.synthesize().
+    func synthesize(text: String, voice: String) async throws -> Data {
+        guard let manager = manager else {
+            throw KokoroTTSError.notInitialized
+        }
+        guard availableVoices.contains(voice) else {
+            throw KokoroTTSError.voiceNotFound(voice)
+        }
+        logger.notice("Kokoro synthesize: \(text.prefix(80))...")
+        let data = try await manager.synthesize(text: text, voice: voice)
+        logger.notice("Kokoro synthesis done: \(data.count) bytes")
+        return data
+    }
+
+    // Yields raw 16-bit little-endian PCM (24 kHz mono, no WAV header) one chunk per
+    // sentence. All Float32 samples for a sentence are collected from KokoroSynthesizer
+    // chunk results, peak-normalised once, and converted to PCM16.
+    func synthesizeStream(text: String, voice: String) -> AsyncThrowingStream<Data, Error> {
+        guard availableVoices.contains(voice) else {
+            return AsyncThrowingStream { continuation in
+                continuation.finish(throwing: KokoroTTSError.voiceNotFound(voice))
+            }
+        }
+
+        let sentences = detectSentences(text)
+        logger.notice("Kokoro synthesizeStream: \(sentences.count) sentence(s)")
+
+        return AsyncThrowingStream { continuation in
+            Task {
+                do {
+                    guard let manager = self.manager else {
+                        throw KokoroTTSError.notInitialized
+                    }
+                    for sentence in sentences {
+                        let result = try await manager.synthesizeDetailed(
+                            text: sentence, voice: voice)
+                        let allSamples = result.chunks.flatMap { $0.samples }
+                        if !allSamples.isEmpty {
+                            continuation.yield(float32ToPCM16(allSamples))
+                        }
+                    }
+                    continuation.finish()
+                }
+                catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Errors
+
+enum KokoroTTSError: Error, CustomStringConvertible {
+    case notInitialized
+    case voiceNotFound(String)
+
+    var description: String {
+        switch self {
+        case .notInitialized:
+            return "Kokoro TTS service has not been initialized."
+        case .voiceNotFound(let voice):
+            return "Voice '\(voice)' is not available. Use a Kokoro voice ID (e.g. 'af_heart', 'am_adam')."
+        }
+    }
+}

--- a/Sources/speech-server/configure.swift
+++ b/Sources/speech-server/configure.swift
@@ -52,6 +52,14 @@ func configure(_ app: Application) async throws {
         app.logger.notice(
             "AVSpeech TTS ready (\(ttsService.availableVoices.count) voices, default: \(ttsService.defaultVoice))."
         )
+    case .kokoro:
+        let ttsService = KokoroTTSService()
+        app.logger.info("Loading Kokoro TTS models (first run will download)...")
+        try await ttsService.initialize(settings: config.tts.kokoro ?? KokoroSettings())
+        app.ttsService = ttsService
+        app.logger.notice(
+            "Kokoro TTS ready (\(ttsService.availableVoices.count) voices, default: \(ttsService.defaultVoice))."
+        )
     }
 
     // STT engine selection

--- a/Tests/speech-serverTests/KokoroConfigTests.swift
+++ b/Tests/speech-serverTests/KokoroConfigTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+import Yams
+
+@testable import speech_server
+
+final class KokoroConfigTests: XCTestCase {
+    // MARK: - Engine parsing
+
+    func testDefaultEngineIsPocketTTS() {
+        let config = ServerConfig()
+        XCTAssertEqual(config.tts.engine, .pocketTts)
+    }
+
+    func testParseKokoroEngine() throws {
+        let yaml = "tts:\n  engine: kokoro\n"
+        let config = try YAMLDecoder().decode(ServerConfig.self, from: yaml)
+        XCTAssertEqual(config.tts.engine, .kokoro)
+    }
+
+    func testPocketTTSEngineStillParses() throws {
+        let yaml = "tts:\n  engine: pocket_tts\n"
+        let config = try YAMLDecoder().decode(ServerConfig.self, from: yaml)
+        XCTAssertEqual(config.tts.engine, .pocketTts)
+    }
+
+    func testAVSpeechEngineStillParses() throws {
+        let yaml = "tts:\n  engine: avspeech\n"
+        let config = try YAMLDecoder().decode(ServerConfig.self, from: yaml)
+        XCTAssertEqual(config.tts.engine, .avspeech)
+    }
+
+    // MARK: - KokoroSettings defaults
+
+    func testKokoroDefaultSettings() {
+        let settings = KokoroSettings()
+        XCTAssertNil(settings.defaultVoice)
+    }
+
+    func testDefaultConfigHasNoKokoroBlock() {
+        let config = ServerConfig()
+        XCTAssertNil(config.tts.kokoro)
+    }
+
+    // MARK: - KokoroSettings YAML parsing
+
+    func testParseKokoroWithCustomVoice() throws {
+        let yaml = """
+            tts:
+              engine: kokoro
+              kokoro:
+                default_voice: am_adam
+            """
+        let config = try YAMLDecoder().decode(ServerConfig.self, from: yaml)
+        XCTAssertEqual(config.tts.engine, .kokoro)
+        XCTAssertEqual(config.tts.kokoro?.defaultVoice, "am_adam")
+    }
+
+    func testMinimalKokoroConfigUsesDefaults() throws {
+        let yaml = "tts:\n  engine: kokoro\n"
+        let config = try YAMLDecoder().decode(ServerConfig.self, from: yaml)
+        let settings = config.tts.kokoro ?? KokoroSettings()
+        XCTAssertNil(settings.defaultVoice)
+    }
+
+    func testEmptyKokoroBlockUsesDefaults() throws {
+        let yaml = """
+            tts:
+              engine: kokoro
+              kokoro: {}
+            """
+        let config = try YAMLDecoder().decode(ServerConfig.self, from: yaml)
+        let settings = config.tts.kokoro ?? KokoroSettings()
+        XCTAssertNil(settings.defaultVoice)
+    }
+
+    // MARK: - Coexistence with other engines
+
+    func testPocketTTSBlockUnaffected() throws {
+        let yaml = """
+            tts:
+              engine: pocket_tts
+              pocket_tts:
+                sanitize_emoji: false
+            """
+        let config = try YAMLDecoder().decode(ServerConfig.self, from: yaml)
+        XCTAssertEqual(config.tts.engine, .pocketTts)
+        XCTAssertEqual(config.tts.pocketTts?.sanitizeEmoji, false)
+        XCTAssertNil(config.tts.kokoro)
+    }
+
+    func testAVSpeechBlockUnaffected() throws {
+        let yaml = """
+            tts:
+              engine: avspeech
+              avspeech:
+                default_voice: Samantha
+            """
+        let config = try YAMLDecoder().decode(ServerConfig.self, from: yaml)
+        XCTAssertEqual(config.tts.engine, .avspeech)
+        XCTAssertEqual(config.tts.avspeech?.defaultVoice, "Samantha")
+        XCTAssertNil(config.tts.kokoro)
+    }
+}

--- a/Tests/speech-serverTests/KokoroTTSServiceTests.swift
+++ b/Tests/speech-serverTests/KokoroTTSServiceTests.swift
@@ -1,0 +1,145 @@
+import XCTest
+
+@testable import speech_server
+
+/// Tests for KokoroTTSService.
+///
+/// These tests exercise the real KokoroTtsManager from FluidAudio.
+/// Model download is required on first run and cached after that.
+final class KokoroTTSServiceTests: XCTestCase {
+    // nonisolated(unsafe): initialization is serialized via DispatchSemaphore in setUp.
+    nonisolated(unsafe) private static var sharedService: KokoroTTSService?
+
+    override class func setUp() {
+        super.setUp()
+        // Initialize once per test class run to avoid repeated model downloads.
+        let service = KokoroTTSService()
+        let semaphore = DispatchSemaphore(value: 0)
+        Task {
+            do {
+                try await service.initialize()
+                sharedService = service
+            }
+            catch {
+                // Service stays nil; tests that need it will fail with a clear message.
+            }
+            semaphore.signal()
+        }
+        semaphore.wait()
+    }
+
+    private var service: KokoroTTSService {
+        guard let s = Self.sharedService else {
+            XCTFail("KokoroTTSService failed to initialize — model download may have failed")
+            return KokoroTTSService()
+        }
+        return s
+    }
+
+    // MARK: - Voice enumeration
+
+    func testAvailableVoicesNotEmpty() {
+        XCTAssertFalse(service.availableVoices.isEmpty)
+    }
+
+    func testDefaultVoiceInAvailableVoices() {
+        XCTAssertTrue(
+            service.availableVoices.contains(service.defaultVoice),
+            "defaultVoice '\(service.defaultVoice)' must appear in availableVoices"
+        )
+    }
+
+    func testAvailableVoicesAreSorted() {
+        XCTAssertEqual(service.availableVoices, service.availableVoices.sorted())
+    }
+
+    // MARK: - Sample rate
+
+    func testSampleRateIs24000() {
+        XCTAssertEqual(service.sampleRate, 24_000)
+    }
+
+    // MARK: - Default voice
+
+    func testDefaultVoiceIsAfHeart() {
+        let defaultService = KokoroTTSService()
+        XCTAssertEqual(defaultService.defaultVoice, "af_heart")
+    }
+
+    func testCustomDefaultVoiceFromSettings() async throws {
+        var settings = KokoroSettings()
+        settings.defaultVoice = "am_adam"
+        let customService = KokoroTTSService()
+        try await customService.initialize(settings: settings)
+        XCTAssertEqual(customService.defaultVoice, "am_adam")
+    }
+
+    // MARK: - synthesize
+
+    func testSynthesizeReturnsWAVData() async throws {
+        let data = try await service.synthesize(text: "Hello.", voice: service.defaultVoice)
+        // WAV starts with "RIFF"
+        XCTAssertEqual(data.prefix(4), Data("RIFF".utf8))
+        // Must have at least the 44-byte header + some audio
+        XCTAssertGreaterThan(data.count, 44)
+    }
+
+    func testSynthesizeInvalidVoiceThrows() async {
+        do {
+            _ = try await service.synthesize(
+                text: "Hello.", voice: "this_voice_does_not_exist_xyz_abc")
+            XCTFail("Expected voiceNotFound error")
+        }
+        catch let error as KokoroTTSError {
+            if case .voiceNotFound = error {
+                // expected
+            }
+            else {
+                XCTFail("Unexpected KokoroTTSError: \(error)")
+            }
+        }
+        catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    // MARK: - synthesizeStream
+
+    func testSynthesizeStreamYieldsChunks() async throws {
+        let stream = service.synthesizeStream(text: "Hello world.", voice: service.defaultVoice)
+        var chunkCount = 0
+        for try await chunk in stream {
+            XCTAssertFalse(chunk.isEmpty)
+            chunkCount += 1
+        }
+        XCTAssertGreaterThan(chunkCount, 0, "synthesizeStream must yield at least one PCM chunk")
+    }
+
+    func testSynthesizeStreamChunksAreEvenLength() async throws {
+        // 16-bit PCM must be an even number of bytes per chunk
+        let stream = service.synthesizeStream(text: "Test sentence.", voice: service.defaultVoice)
+        for try await chunk in stream {
+            XCTAssertEqual(chunk.count % 2, 0, "Each PCM chunk must have an even byte count")
+        }
+    }
+
+    func testSynthesizeStreamInvalidVoiceThrows() async {
+        let stream = service.synthesizeStream(
+            text: "Hello.", voice: "this_voice_does_not_exist_xyz_abc")
+        do {
+            for try await _ in stream {}
+            XCTFail("Expected voiceNotFound error")
+        }
+        catch let error as KokoroTTSError {
+            if case .voiceNotFound = error {
+                // expected
+            }
+            else {
+                XCTFail("Unexpected KokoroTTSError: \(error)")
+            }
+        }
+        catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+}

--- a/speech-server.yaml.example
+++ b/speech-server.yaml.example
@@ -26,7 +26,7 @@ stt:
                         # v2 = Parakeet TDT 0.6B v2, English-only (higher recall)
 
 tts:
-  engine: pocket_tts    # Text-to-speech engine: pocket_tts | avspeech
+  engine: pocket_tts    # Text-to-speech engine: pocket_tts | avspeech | kokoro
 
   # PocketTTS settings (only used when engine: pocket_tts)
   pocket_tts:
@@ -37,3 +37,8 @@ tts:
   # avspeech:
   #   default_voice: Samantha   # Short name or full identifier; nil = system locale default
   #   sample_rate: 22050        # Native AVSpeech output rate (Hz); change only if needed
+
+  # Kokoro TTS settings (only used when engine: kokoro)
+  # Uses FluidAudio's Kokoro model — 50 voices across 8 languages, 24 kHz, high quality.
+  # kokoro:
+  #   default_voice: af_heart   # Any Kokoro voice ID (e.g. af_heart, am_adam); default af_heart


### PR DESCRIPTION
## Summary

- Integrates FluidAudio's **Kokoro** CoreML model as a third TTS engine (`engine: kokoro` in config)
- Bumps FluidAudio to `0.12.4+` — fixes the `.int8` SDK guard bug (issue #363) and adds `KokoroTtsManager`
- 50 voices across 8 languages (American English, British English, Spanish, French, Hindi, Italian, Japanese, Brazilian Portuguese, Mandarin); synthesises at 24 kHz
- Default voice: `af_heart` (American English female, FluidAudio's recommended voice)
- Optional `default_voice` setting per config block

**New files:**
- `Sources/speech-server/Services/KokoroTTSService.swift` — wraps `KokoroTtsManager`; `synthesize()` returns WAV directly from the manager; `synthesizeStream()` splits text into sentences, calls `synthesizeDetailed()` per sentence, converts `Float32` samples via `float32ToPCM16()`
- `Tests/speech-serverTests/KokoroConfigTests.swift` — 11 unit tests for YAML parsing (already existed in the repo, now compiles)
- `Tests/speech-serverTests/KokoroTTSServiceTests.swift` — 11 integration tests against the real Kokoro model

**Modified files:**
- `Package.swift` — FluidAudio pinned to `from: "0.12.4"`
- `ServerConfig.swift` — `TTSEngine.kokoro`, `KokoroSettings`, `TTSConfig.kokoro`
- `configure.swift` — `.kokoro` case in TTS engine switch
- `speech-server.yaml.example` — kokoro engine and settings documented
- `README.md` — Kokoro added to TTS engines table and described in its own section
- `AGENTS.md` — KokoroTTSService architecture section, updated test/CI tables
- `.github/workflows/tests.yml` — `~/.cache/fluidaudio` added to CI model cache

## Test plan

- [x] `swift test --filter KokoroConfig` — 11 unit tests pass (no models needed)
- [x] `swift test --filter KokoroTTSService` — 11 integration tests pass (Kokoro model downloaded)
- [x] `swift test` — all 248 tests pass
- [x] `swift format lint --strict` — no formatting issues
- [x] Manual: set `engine: kokoro` in `speech-server.yaml`, `curl POST /v1/audio/speech`
- [ ] CI green on macOS 15

🤖 Generated with [Claude Code](https://claude.com/claude-code)