### PR TITLE
fix: AVSpeech no longer vocalizes appended periods as "full stop"

### DIFF
--- a/Sources/speech-server/Services/AVSpeechTTSService.swift
+++ b/Sources/speech-server/Services/AVSpeechTTSService.swift
@@ -75,7 +75,7 @@ final class AVSpeechTTSService: TTSService, Sendable {
         }
 
         var allSamples: [Float] = []
-        for sentence in detectSentences(text) {
+        for sentence in splitSentences(text) {
             let samples = try await synthesizeFloatSamples(
                 text: sentence, voiceIdentifier: identifier)
             allSamples.append(contentsOf: samples)
@@ -102,7 +102,7 @@ final class AVSpeechTTSService: TTSService, Sendable {
             }
         }
 
-        let sentences = detectSentences(text)
+        let sentences = splitSentences(text)
         logger.notice("AVSpeech synthesizeStream: \(sentences.count) sentence(s)")
 
         return AsyncThrowingStream { continuation in

--- a/Sources/speech-server/Services/SentenceDetection.swift
+++ b/Sources/speech-server/Services/SentenceDetection.swift
@@ -38,6 +38,26 @@ func splitCompleteSentences(_ text: String) -> (complete: [String], remainder: S
     }
 }
 
+/// Split text into sentences without modifying punctuation.
+///
+/// Unlike `detectSentences()`, the trailing fragment is returned as-is — no period is appended.
+/// Use this for engines (e.g. AVSpeechSynthesizer) that handle unterminated text natively and
+/// would vocalize an appended period as "full stop".
+///
+/// Examples:
+/// - `"Hello world"` → `["Hello world"]`
+/// - `"Hello world."` → `["Hello world."]`
+/// - `"Hello. World"` → `["Hello.", "World"]`
+/// - `""` → `[]`
+func splitSentences(_ text: String) -> [String] {
+    let (complete, remainder) = splitCompleteSentences(text)
+    var result = complete
+    if !remainder.isEmpty {
+        result.append(remainder)
+    }
+    return result
+}
+
 /// Split text into sentences, ensuring every one ends with terminal punctuation.
 ///
 /// This is a convenience wrapper over `splitCompleteSentences`: the incomplete remainder

--- a/Sources/speech-server/Services/SentenceDetection.swift
+++ b/Sources/speech-server/Services/SentenceDetection.swift
@@ -19,7 +19,7 @@ func splitCompleteSentences(_ text: String) -> (complete: [String], remainder: S
 
     var sentences: [String] = []
     tokenizer.enumerateTokens(in: text.startIndex..<text.endIndex) { range, _ in
-        let s = String(text[range]).trimmingCharacters(in: .whitespaces)
+        let s = String(text[range]).trimmingCharacters(in: .whitespacesAndNewlines)
         guard !s.isEmpty else { return true }
         sentences.append(s)
         return true

--- a/Sources/speech-server/Wyoming/WyomingSession.swift
+++ b/Sources/speech-server/Wyoming/WyomingSession.swift
@@ -110,10 +110,7 @@ actor WyomingSession {
             return AsyncStream { continuation in
                 Task {
                     if !remainingText.isEmpty {
-                        // Ensure terminal punctuation before synthesizing the final fragment
-                        var text = remainingText
-                        if let last = text.last, !".!?".contains(last) { text += "." }
-                        await self.streamSentences([text], voice: voice, continuation: continuation)
+                        await self.streamSentences([remainingText], voice: voice, continuation: continuation)
                     }
                     continuation.yield(WyomingEvent(type: "synthesize-stopped").serialize())
                     continuation.finish()

--- a/Tests/speech-serverTests/SentenceDetectionTests.swift
+++ b/Tests/speech-serverTests/SentenceDetectionTests.swift
@@ -65,6 +65,20 @@ final class SentenceDetectionTests: XCTestCase {
         XCTAssertEqual(remainder, "")
     }
 
+    func testSplitCompleteSentencesParagraphBreak() {
+        // \n\n must not leak a bare "\n" token into the sentence list.
+        let (complete, remainder) = splitCompleteSentences("Hello world.\n\nGoodbye.")
+        XCTAssertEqual(complete, ["Hello world.", "Goodbye."])
+        XCTAssertEqual(remainder, "")
+    }
+
+    func testSplitCompleteSentencesParagraphBreakNoTerminalPunct() {
+        // Text without terminal punctuation around \n\n must still be split cleanly.
+        let (complete, remainder) = splitCompleteSentences("Hello world.\n\nGoodbye")
+        XCTAssertEqual(complete, ["Hello world."])
+        XCTAssertEqual(remainder, "Goodbye")
+    }
+
     // MARK: - splitSentences
 
     func testSplitSentencesNoPunctuation() {

--- a/Tests/speech-serverTests/SentenceDetectionTests.swift
+++ b/Tests/speech-serverTests/SentenceDetectionTests.swift
@@ -64,4 +64,39 @@ final class SentenceDetectionTests: XCTestCase {
         XCTAssertEqual(complete, [])
         XCTAssertEqual(remainder, "")
     }
+
+    // MARK: - splitSentences
+
+    func testSplitSentencesNoPunctuation() {
+        // Text without terminal punctuation must be returned as-is — no period appended.
+        let result = splitSentences("Hello world")
+        XCTAssertEqual(result, ["Hello world"])
+    }
+
+    func testSplitSentencesWithPeriod() {
+        XCTAssertEqual(splitSentences("Hello world."), ["Hello world."])
+    }
+
+    func testSplitSentencesWithQuestionMark() {
+        XCTAssertEqual(splitSentences("Who are you?"), ["Who are you?"])
+    }
+
+    func testSplitSentencesMultipleComplete() {
+        XCTAssertEqual(splitSentences("Hello. World!"), ["Hello.", "World!"])
+    }
+
+    func testSplitSentencesMixedCompleteAndRemainder() {
+        let result = splitSentences("Hello world. This is")
+        XCTAssertEqual(result, ["Hello world.", "This is"])
+    }
+
+    func testSplitSentencesEmpty() {
+        XCTAssertEqual(splitSentences(""), [])
+    }
+
+    func testSplitSentencesRemainderNotModified() {
+        // Unlike detectSentences, the remainder must NOT have a period appended.
+        let result = splitSentences("One. Two")
+        XCTAssertEqual(result.last, "Two")
+    }
 }


### PR DESCRIPTION
## Summary

- `detectSentences()` appends a literal `.` to text lacking terminal punctuation — correct for PocketTTS/Kokoro (prosody hint) but AVSpeechSynthesizer vocalizes it as "full stop". Adds `splitSentences()` which returns the trailing fragment unmodified, and switches `AVSpeechTTSService` to use it.
- `NLTokenizer` splits `"A.\n\nB"` into `["A.\n", "\n", "B"]`. The previous `.whitespaces` trim left the bare `"\n"` token in the sentence list; passing it to `AVSpeechSynthesizer` likely caused the completion callback to never fire, hanging the async continuation and cutting off all speech after the first `\n\n`. Fixed by switching to `.whitespacesAndNewlines`.
- Removes redundant period-append in `WyomingSession`'s `synthesize-stop` handler — each engine's `synthesizeStream()` already handles its own preprocessing.

## Test plan

- [x] 7 new unit tests for `splitSentences()` — all pass
- [x] 2 new regression tests for `\n\n` in `splitCompleteSentences` — all pass
- [x] Full unit test suite (167 tests) passes
- [x] Manual: run server with `tts.engine: avspeech`, send text with `\n\n` (e.g. `"Hello world.\n\nGoodbye."`), verify both paragraphs are spoken and no "full stop" is heard

🤖 Generated with [Claude Code](https://claude.com/claude-code)