### PR TITLE
Update to FluidAudio 0.13.4 to fix Swift 6 concurrency error

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "00c2196a216d4f37501c0fa782e581fd6278ea4140a973bb37afb4f33acbe7da",
+  "originHash" : "fedefcf831ede4addbf283cc16f487bbff1734a6f826233a936262e5c14f1d46",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -29,21 +29,12 @@
       }
     },
     {
-      "identity" : "eventsource",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattt/EventSource.git",
-      "state" : {
-        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
-        "version" : "1.4.1"
-      }
-    },
-    {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "2d2979486bd7125558fe783741ef9a2757b3c1bb",
-        "version" : "0.12.5"
+        "revision" : "6c40eca4310efffe80e723f1e628f6cf76d3feaf",
+        "version" : "0.13.5"
       }
     },
     {
@@ -155,24 +146,6 @@
       }
     },
     {
-      "identity" : "swift-huggingface",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-huggingface.git",
-      "state" : {
-        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
-        "version" : "0.9.0"
-      }
-    },
-    {
-      "identity" : "swift-jinja",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-jinja.git",
-      "state" : {
-        "revision" : "f731f03bf746481d4fda07f817c3774390c4d5b9",
-        "version" : "2.3.2"
-      }
-    },
-    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
@@ -272,15 +245,6 @@
       }
     },
     {
-      "identity" : "swift-transformers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-transformers",
-      "state" : {
-        "revision" : "eed7264ac5e4ec5dfa6165c6e5c5577364344fe4",
-        "version" : "1.2.0"
-      }
-    },
-    {
       "identity" : "vapor",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/vapor.git",
@@ -305,15 +269,6 @@
       "state" : {
         "revision" : "deaf82e867fa2cbd3cd865978b079bfcf384ac28",
         "version" : "6.2.1"
-      }
-    },
-    {
-      "identity" : "yyjson",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ibireme/yyjson.git",
-      "state" : {
-        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
-        "version" : "0.12.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -7,10 +7,9 @@ let package = Package(
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.76.0"),
-        // FluidAudio 0.12.3 introduced KokoroTtsManager (Kokoro TTS engine).
-        // The .int8 SDK guard bug (issue #363) is fixed in v0.12.4 via #if canImport(FoundationModels).
-        // Require v0.12.4+ so CI on macOS 15 works and Kokoro TTS is available.
-        .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.12.4"),
+        // FluidAudio 0.13.4+ fixes Swift 6.3 concurrency errors in StreamingAsrManager
+        // (FluidInference/FluidAudio#448).
+        .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.13.4"),
         .package(url: "https://github.com/vapor/multipart-kit.git", from: "4.0.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "6.0.1"),
         // async-http-client 1.31+ depends on swift-configuration, which uses Data.bytes.

--- a/Sources/speech-server/Services/FluidSTTService.swift
+++ b/Sources/speech-server/Services/FluidSTTService.swift
@@ -14,7 +14,7 @@ final class FluidSTTService: STTService, @unchecked Sendable {
     func initialize(modelVersion: AsrModelVersion = .v3) async throws {
         let models = try await AsrModels.downloadAndLoad(version: modelVersion)
         let manager = AsrManager(config: .default)
-        try await manager.initialize(models: models)
+        try await manager.loadModels(models)
         self.asrManager = manager
         self.vadManager = try await VadManager()
     }
@@ -28,7 +28,7 @@ final class FluidSTTService: STTService, @unchecked Sendable {
 
         let diskSource: DiskBackedAudioSampleSource
         do {
-            let factory = StreamingAudioSourceFactory()
+            let factory = AudioSourceFactory()
             let (source, _) = try factory.makeDiskBackedSource(
                 from: audioURL, targetSampleRate: 16000
             )


### PR DESCRIPTION
This also involved some breaking code renames, so not just a Package.swift change.

Error was:

```
.build/checkouts/FluidAudio/Sources/FluidAudio/ASR/Streaming/StreamingAsrManager.swift:379:77: error:
sending 'asrManager' risks causing data races [#SendingRisksDataRace]
377 |
378 |             // Call AsrManager directly with deduplication
379 |             let (tokens, timestamps, confidences, _) = try await asrManager.transcribeStreamingChunk(
    |                                                                             |- error: sending 'asrManager' risks causing data races
[#SendingRisksDataRace]
    |                                                                             `- note: sending 'self'-isolated 'asrManager' to nonisolated
instance method 'transcribeStreamingChunk(_:source:previousTokens:isLastChunk:)' risks causing data races between nonisolated and 'self'-isolated
uses
380 |                 windowSamples,
381 |                 source: audioSource,
```