### PR TITLE
Add Qwen3 ASR as alternative STT engine with language hinting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ ServerConfig
   ├─ servers: ServersConfig
   │   ├─ http: HTTPConfig          (host, port, uploadLimitMB)
   │   └─ wyoming: WyomingConfig    (host, port)
-  ├─ stt: STTConfig                (engine, parakeet settings)
+  ├─ stt: STTConfig                (engine, parakeet/qwen3 settings)
   └─ tts: TTSConfig                (engine, pocket_tts/avspeech/kokoro settings)
 ```
 
@@ -136,6 +136,24 @@ multipart parsing, keeping peak RAM at O(chunk_size) during upload:
   Zero-padding the tail is safe -- the model handles trailing silence natively.
 
 Use `source: .system` for file/API transcription, `source: .microphone` for live capture.
+
+### Qwen3STTService
+
+`Qwen3STTService` wraps FluidAudio's `Qwen3AsrManager` (encoder-decoder ASR, 30+ languages):
+
+1. On init: takes optional `language` hint (ISO 639-1 code, e.g. `"en"`).
+2. On initialize: downloads Qwen3 CoreML models via `Qwen3AsrModels.download(variant:)` (cached at `~/Library/Application Support/FluidAudio/Models/`), creates `Qwen3AsrManager()`, calls `manager.loadModels(from:)`.
+3. On transcribe: converts audio to 16 kHz mono via `DiskBackedAudioSampleSource`, runs VAD to find speech segments (same as `FluidSTTService`), calls `manager.transcribe(audioSamples:language:)` on each segment. The 30-second max audio limit is enforced per segment.
+4. Returns `TranscriptionResult` with segment-level timing from VAD but **no word-level timestamps** (Qwen3 returns plain text).
+5. Must call `initialize()` before first use — will throw `Qwen3STTError.notInitialized` otherwise.
+6. `@available(macOS 15, *)` — requires macOS 15+ for CoreML features used by Qwen3.
+7. `@unchecked Sendable` because `Qwen3AsrManager` is an actor.
+
+**Language hinting**: Unlike Parakeet (which auto-detects language with no way to override), Qwen3 accepts an explicit `language` parameter. Setting `language: "en"` forces English decoding, which can improve accuracy for non-American English accents (e.g. British English) by preventing the multilingual model from misinterpreting accent features as other languages.
+
+**Model variants**: `Qwen3AsrVariant.int8` (~900 MB, default) and `.f32` (~1.75 GB). Configured via `variant` in YAML.
+
+**Errors**: `Qwen3STTError.notInitialized`, `Qwen3STTError.audioConversionFailed(Error)`, `Qwen3STTError.audioTooShort`, `Qwen3STTError.unsupportedPlatform`.
 
 ### FluidTTSService
 
@@ -281,7 +299,7 @@ recording ──audio-stop──→ [call STTService.transcribe, send transcript
 any state ──describe──→ [send info with both asr + tts capabilities] (state unchanged)
 ```
 
-The `info` response advertises both `asr` and `tts` arrays so Home Assistant knows this single port handles both services. The TTS program includes `supports_synthesize_streaming: true` to advertise HA 2025.07+ streaming support.
+The `info` response advertises both `asr` and `tts` arrays so Home Assistant knows this single port handles both services. The TTS program includes `supports_synthesize_streaming: true` to advertise HA 2025.07+ streaming support. ASR model name and language list are driven by `STTInfo` (passed through `WyomingServer` → `WyomingSession`), with static presets `.parakeet` and `.qwen3`.
 
 **Streaming TTS**: `handle(event:)` returns `AsyncStream<Data>` (non-async). For `synthesize`, the stream yields `audio-start` + each `audio-chunk` + `audio-stop` incrementally as TTS chunks arrive — `audio-start` is withheld until the first chunk so a completely failed synthesis sends nothing. State mutations (e.g. `state = .awaitingAudio`) happen synchronously before the stream is returned, so callers can immediately make the next `handle` call without draining the stream first. All other event types pre-fill the stream synchronously and finish immediately.
 
@@ -313,6 +331,7 @@ Both `http.host` and `wyoming.host` are independently configurable — they do n
 | `AVSpeechTTSServiceTests.swift` | Real `AVSpeechTTSService` (uses macOS system voices) | No |
 | `KokoroConfigTests.swift` | YAML parsing for `kokoro` engine and `KokoroSettings` | No |
 | `KokoroTTSServiceTests.swift` | Real `KokoroTTSService` (Kokoro CoreML models) | Yes |
+| `Qwen3ConfigTests.swift` | YAML parsing for `qwen3` engine and `Qwen3STTSettings` | No |
 | `Helpers/MockServices.swift` | `MockTTSService` + `MockSTTService` for session tests | No |
 
 ### Error handling
@@ -396,6 +415,7 @@ swift test --filter ServerConfig  # run a specific test class
 | `AVSpeechTTSServiceTests.swift` | Unit | Real `AVSpeechTTSService` using macOS system voices — no models needed |
 | `KokoroConfigTests.swift` | Unit | YAML parsing for `kokoro` engine and `KokoroSettings` — no models needed |
 | `KokoroTTSServiceTests.swift` | Integration | Real `KokoroTTSService` with Kokoro CoreML models |
+| `Qwen3ConfigTests.swift` | Unit | YAML parsing for `qwen3` engine and `Qwen3STTSettings` — no models needed |
 | `Helpers/MockServices.swift` | Helper | MockTTSService + MockSTTService |
 
 **First run**: integration tests load real FluidAudio models (STT + TTS). Model download takes several minutes; subsequent runs use the on-disk cache and start in seconds. The shared app singleton (`_appTask` in `TestApp.swift`) ensures models are initialized once per `swift test` invocation.

--- a/README.md
+++ b/README.md
@@ -43,9 +43,12 @@ servers:
     port: 10300           # TCP port for Wyoming protocol (Home Assistant). 0 = disabled.
 
 stt:
-  engine: parakeet      # Currently only: parakeet (NVIDIA Parakeet TDT via FluidAudio)
+  engine: parakeet      # parakeet (default) | qwen3
   parakeet:
     model_version: v3   # v3 = multilingual (25 langs, default), v2 = English-only
+  # qwen3:              # Qwen3 ASR — encoder-decoder model with language hinting (macOS 15+)
+  #   variant: int8     # int8 (default, ~900 MB) | f32 (~1.75 GB)
+  #   language: en      # ISO 639-1 code; omit for auto-detect
 
 tts:
   engine: pocket_tts    # pocket_tts (default) | avspeech | kokoro
@@ -61,6 +64,35 @@ tts:
 ```
 
 All fields are optional — omitted fields use the defaults shown above.
+
+### STT engines
+
+Two STT engines are available:
+
+| Engine | `engine:` value | Languages | Downloads | Notes |
+|--------|----------------|-----------|-----------|-------|
+| Parakeet TDT | `parakeet` | 25 (v3) or English-only (v2) | ~500 MB on first start | Default, CTC/TDT model, word-level timestamps |
+| Qwen3 ASR | `qwen3` | 30+ with explicit language hinting | ~900 MB (int8) or ~1.75 GB (f32) | Encoder-decoder, macOS 15+ required |
+
+#### `parakeet` (default)
+
+Uses [FluidAudio](https://github.com/FluidInference/FluidAudio)'s Parakeet TDT model (based on NVIDIA's architecture). Supports word-level timestamps and VAD-based segmentation. Two model versions: `v3` (multilingual, 25 languages) and `v2` (English-only, higher recall).
+
+#### `qwen3` — encoder-decoder ASR with language hinting
+
+Uses FluidAudio's Qwen3 ASR model — an encoder-decoder architecture (Whisper-family) that supports explicit language hinting via the `language` setting. This can improve accuracy for specific accents or languages since the model doesn't need to auto-detect the language. Requires macOS 15+.
+
+```yaml
+stt:
+  engine: qwen3
+  qwen3:
+    variant: int8     # int8 (default, ~900 MB) or f32 (~1.75 GB)
+    language: en      # ISO 639-1 code — set this for best results with a known language
+```
+
+Supported languages: zh, en, yue, ar, de, fr, es, pt, id, it, ko, ru, th, vi, ja, tr, hi, ms, nl, sv, da, fi, pl, cs, fil, fa, el, hu, mk, ro.
+
+**Note:** Qwen3 does not provide word-level timestamps. The `verbose_json` response will include segment-level timing (from VAD) but the `words` array will be empty.
 
 ### TTS engines
 
@@ -437,6 +469,7 @@ Sources/speech-server/
   Services/
     STTService.swift               # STT protocol + DI
     FluidSTTService.swift          # FluidAudio ASR implementation (parakeet engine)
+    Qwen3STTService.swift          # FluidAudio Qwen3 ASR implementation (qwen3 engine)
     AudioFormatDetection.swift     # Magic-byte audio format detection
     TTSService.swift               # TTS protocol + DI
     FluidTTSService.swift          # FluidAudio PocketTTS implementation (pocket_tts engine)

--- a/Sources/speech-server/ServerConfig.swift
+++ b/Sources/speech-server/ServerConfig.swift
@@ -115,26 +115,31 @@ struct HTTPConfig: Codable, Sendable {
 struct STTConfig: Codable, Sendable {
     var engine: STTEngine
     var parakeet: ParakeetSettings?
+    var qwen3: Qwen3STTSettings?
 
     init() {
         engine = .parakeet
         parakeet = nil
+        qwen3 = nil
     }
 
     init(from decoder: any Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         engine = try c.decodeIfPresent(STTEngine.self, forKey: .engine) ?? .parakeet
         parakeet = try c.decodeIfPresent(ParakeetSettings.self, forKey: .parakeet)
+        qwen3 = try c.decodeIfPresent(Qwen3STTSettings.self, forKey: .qwen3)
     }
 
     enum CodingKeys: String, CodingKey {
         case engine
         case parakeet = "parakeet"
+        case qwen3 = "qwen3"
     }
 }
 
 enum STTEngine: String, Codable, Sendable {
     case parakeet = "parakeet"
+    case qwen3 = "qwen3"
 }
 
 struct ParakeetSettings: Codable, Sendable {
@@ -151,6 +156,30 @@ struct ParakeetSettings: Codable, Sendable {
 
     enum CodingKeys: String, CodingKey {
         case modelVersion = "model_version"
+    }
+}
+
+struct Qwen3STTSettings: Codable, Sendable {
+    /// Model variant. "int8" = quantized (~900 MB, default), "f32" = full precision (~1.75 GB).
+    var variant: String
+    /// Language hint for transcription (ISO 639-1 code, e.g. "en", "fr").
+    /// Nil = auto-detect language from audio.
+    var language: String?
+
+    init() {
+        variant = "int8"
+        language = nil
+    }
+
+    init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        variant = try c.decodeIfPresent(String.self, forKey: .variant) ?? "int8"
+        language = try c.decodeIfPresent(String.self, forKey: .language)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case variant
+        case language
     }
 }
 

--- a/Sources/speech-server/Services/Qwen3STTService.swift
+++ b/Sources/speech-server/Services/Qwen3STTService.swift
@@ -1,0 +1,151 @@
+import FluidAudio
+import Foundation
+import Logging
+
+@available(macOS 15, *)
+final class Qwen3STTService: STTService, @unchecked Sendable {
+    private var manager: Qwen3AsrManager?
+    private var vadManager: VadManager?
+    private let language: String?
+    private var logger: Logger = {
+        var l = Logger(label: "Qwen3STTService")
+        l.logLevel = .notice
+        return l
+    }()
+
+    init(language: String?) {
+        self.language = language
+    }
+
+    func initialize(variant: Qwen3AsrVariant = .int8) async throws {
+        let mgr = Qwen3AsrManager()
+        let modelDir = try await Qwen3AsrModels.download(variant: variant)
+        try await mgr.loadModels(from: modelDir)
+        self.manager = mgr
+        self.vadManager = try await VadManager()
+    }
+
+    func transcribe(audioURL: URL) async throws -> TranscriptionResult {
+        guard let manager, let vadManager else {
+            throw Qwen3STTError.notInitialized
+        }
+
+        logger.notice("Transcribing (Qwen3): \(audioURL.lastPathComponent)")
+
+        let diskSource: DiskBackedAudioSampleSource
+        do {
+            let factory = AudioSourceFactory()
+            let (source, _) = try factory.makeDiskBackedSource(
+                from: audioURL, targetSampleRate: 16000
+            )
+            diskSource = source
+        }
+        catch {
+            throw Qwen3STTError.audioConversionFailed(error)
+        }
+        defer { diskSource.cleanup() }
+
+        let totalSamples = diskSource.sampleCount
+        let totalDuration = Double(totalSamples) / 16000.0
+
+        guard totalSamples > 160 else {
+            throw Qwen3STTError.audioTooShort
+        }
+
+        // Run VAD in streaming chunks to find speech segments.
+        // Qwen3 has a 30-second max audio limit, so we must segment.
+        let chunkSize = VadManager.chunkSize
+        var vadResults: [VadResult] = []
+        var chunk = [Float](repeating: 0, count: chunkSize)
+        var vadStreamState = VadStreamState.initial()
+
+        for chunkOffset in stride(from: 0, to: totalSamples, by: chunkSize) {
+            let count = min(chunkSize, totalSamples - chunkOffset)
+            try diskSource.copySamples(into: &chunk, offset: chunkOffset, count: count)
+            let vadChunk = count == chunkSize ? chunk : Array(chunk[..<count])
+            let streamResult = try await vadManager.processStreamingChunk(
+                vadChunk, state: vadStreamState
+            )
+            vadStreamState = streamResult.state
+            vadResults.append(
+                VadResult(
+                    probability: streamResult.probability,
+                    isVoiceActive: streamResult.state.triggered,
+                    processingTime: 0,
+                    outputState: streamResult.state.modelState
+                ))
+        }
+
+        let vadSegments = await vadManager.segmentSpeech(
+            from: vadResults, totalSamples: totalSamples
+        )
+
+        guard !vadSegments.isEmpty else {
+            logger.notice("No speech detected: duration=\(totalDuration)s")
+            return TranscriptionResult(text: "", duration: totalDuration, words: [], segments: [])
+        }
+
+        var segmentResults: [SegmentResult] = []
+
+        // Qwen3 max audio is 30 seconds = 480,000 samples at 16 kHz.
+        let maxSamples = 30 * 16_000
+
+        for vadSeg in vadSegments {
+            let startSample = vadSeg.startSample(sampleRate: 16000)
+            let endSample = min(vadSeg.endSample(sampleRate: 16000), totalSamples)
+            let segLength = endSample - startSample
+            guard segLength >= 160 else { continue }
+
+            // Qwen3 requires >= 16,000 samples (1 second); pad shorter segments.
+            let paddedLength = max(min(segLength, maxSamples), 16_000)
+            let copyLength = min(segLength, maxSamples)
+            var slicedSamples = [Float](repeating: 0, count: paddedLength)
+            try diskSource.copySamples(into: &slicedSamples, offset: startSample, count: copyLength)
+
+            let text = try await manager.transcribe(
+                audioSamples: slicedSamples,
+                language: language
+            )
+
+            segmentResults.append(
+                SegmentResult(
+                    text: text.trimmingCharacters(in: .whitespacesAndNewlines),
+                    start: vadSeg.startTime.rounded3,
+                    end: vadSeg.endTime.rounded3,
+                    words: [],
+                    confidence: 1.0
+                ))
+        }
+
+        let fullText = segmentResults.map { $0.text }.joined(separator: " ")
+
+        logger.notice("Transcription done (Qwen3): duration=\(totalDuration)s, segments=\(segmentResults.count)")
+        logger.debug("Transcription text: '\(fullText)'")
+
+        return TranscriptionResult(text: fullText, duration: totalDuration, words: [], segments: segmentResults)
+    }
+}
+
+extension Double {
+    fileprivate var rounded3: Double { (self * 1000).rounded() / 1000 }
+}
+
+enum Qwen3STTError: Error, CustomStringConvertible {
+    case notInitialized
+    case audioConversionFailed(Error)
+    case audioTooShort
+    case unsupportedPlatform
+
+    var description: String {
+        switch self {
+        case .notInitialized:
+            return "Qwen3 ASR service has not been initialized."
+        case .audioConversionFailed(let underlying):
+            return "Audio conversion failed: \(underlying)"
+        case .audioTooShort:
+            return "Audio file is too short to transcribe."
+        case .unsupportedPlatform:
+            return "Qwen3 ASR requires macOS 15 or later."
+        }
+    }
+}

--- a/Sources/speech-server/Wyoming/WyomingServer.swift
+++ b/Sources/speech-server/Wyoming/WyomingServer.swift
@@ -15,27 +15,37 @@ final class WyomingServer: LifecycleHandler, @unchecked Sendable {
     private let port: Int
     private let ttsService: any TTSService
     private let sttService: any STTService
+    private let sttInfo: STTInfo
     private let logger: Logger
     private var serverChannel: (any Channel)?
 
-    init(host: String, port: Int, ttsService: any TTSService, sttService: any STTService, logger: Logger) {
+    init(
+        host: String,
+        port: Int,
+        ttsService: any TTSService,
+        sttService: any STTService,
+        sttInfo: STTInfo = .parakeet,
+        logger: Logger
+    ) {
         self.host = host
         self.port = port
         self.ttsService = ttsService
         self.sttService = sttService
+        self.sttInfo = sttInfo
         self.logger = logger
     }
 
     func didBoot(_ application: Application) throws {
         let tts = ttsService
         let stt = sttService
+        let info = sttInfo
         let log = logger
 
         let bootstrap = ServerBootstrap(group: application.eventLoopGroup)
             .serverChannelOption(ChannelOptions.backlog, value: 256)
             .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
-                let session = WyomingSession(ttsService: tts, sttService: stt, logger: log)
+                let session = WyomingSession(ttsService: tts, sttService: stt, sttInfo: info, logger: log)
                 let handler = WyomingChannelHandler(session: session, logger: log)
                 return channel.pipeline.addHandler(handler)
             }

--- a/Sources/speech-server/Wyoming/WyomingSession.swift
+++ b/Sources/speech-server/Wyoming/WyomingSession.swift
@@ -16,9 +16,33 @@ import Logging
 /// recording ──audio-stop──→ [call STTService.transcribe, send transcript] ──→ idle
 /// any state ──describe──→ [send info with both asr + tts capabilities] (state unchanged)
 /// ```
+/// Metadata about the active STT engine, used in the Wyoming `info` response.
+struct STTInfo: Sendable {
+    let modelName: String
+    let modelDescription: String
+    let languages: [String]
+
+    static let parakeet = STTInfo(
+        modelName: "parakeet-tdt-0.6b",
+        modelDescription: "Parakeet TDT 0.6B on-device ASR via FluidAudio",
+        languages: ["en"]
+    )
+
+    static let qwen3 = STTInfo(
+        modelName: "qwen3-asr",
+        modelDescription: "Qwen3 ASR on-device speech recognition via FluidAudio",
+        languages: [
+            "zh", "en", "yue", "ar", "de", "fr", "es", "pt", "id", "it",
+            "ko", "ru", "th", "vi", "ja", "tr", "hi", "ms", "nl", "sv",
+            "da", "fi", "pl", "cs", "fil", "fa", "el", "hu", "mk", "ro",
+        ]
+    )
+}
+
 actor WyomingSession {
     private let ttsService: any TTSService
     private let sttService: any STTService
+    private let sttInfo: STTInfo
     private var state: State = .idle
     private let logger: Logger
 
@@ -29,9 +53,15 @@ actor WyomingSession {
         case streamingSynthesize(voice: String, textBuffer: String)
     }
 
-    init(ttsService: any TTSService, sttService: any STTService, logger: Logger = Logger(label: "WyomingSession")) {
+    init(
+        ttsService: any TTSService,
+        sttService: any STTService,
+        sttInfo: STTInfo = .parakeet,
+        logger: Logger = Logger(label: "WyomingSession")
+    ) {
         self.ttsService = ttsService
         self.sttService = sttService
+        self.sttInfo = sttInfo
         self.logger = logger
     }
 
@@ -328,12 +358,12 @@ actor WyomingSession {
         // Two-level ASR hierarchy: AsrProgram → models: [AsrModel]
         // languages lives on AsrModel, not on AsrProgram
         let asrModel = WyomingValue.object([
-            "name": .string("parakeet-tdt-0.6b"),
-            "description": .string("Parakeet TDT 0.6B on-device ASR via FluidAudio"),
+            "name": .string(sttInfo.modelName),
+            "description": .string(sttInfo.modelDescription),
             "attribution": asrAttribution,
             "installed": .bool(true),
             "version": .string("1.0.0"),
-            "languages": .array([.string("en")]),
+            "languages": .array(sttInfo.languages.map { .string($0) }),
         ])
 
         let asrProgram = WyomingValue.object([

--- a/Sources/speech-server/configure.swift
+++ b/Sources/speech-server/configure.swift
@@ -80,6 +80,28 @@ func configure(_ app: Application) async throws {
         try await sttService.initialize(modelVersion: modelVersion)
         app.sttService = sttService
         app.logger.info("ASR models loaded. Server ready.")
+    case .qwen3:
+        guard #available(macOS 15, *) else {
+            throw Abort(.internalServerError, reason: "Qwen3 ASR requires macOS 15 or later.")
+        }
+        let settings = config.stt.qwen3 ?? Qwen3STTSettings()
+        let variantStr = settings.variant
+        let variant: Qwen3AsrVariant =
+            switch variantStr {
+            case "int8": .int8
+            case "f32": .f32
+            default:
+                throw Abort(
+                    .internalServerError,
+                    reason: "Unknown Qwen3 variant '\(variantStr)'; valid values are 'int8' and 'f32'.")
+            }
+        let langDesc = settings.language.map { "language=\($0)" } ?? "auto-detect"
+        app.logger.info(
+            "Loading ASR models (Qwen3 \(variantStr), \(langDesc), first run will download ~minutes)...")
+        let sttService = Qwen3STTService(language: settings.language)
+        try await sttService.initialize(variant: variant)
+        app.sttService = sttService
+        app.logger.info("Qwen3 ASR models loaded. Server ready.")
     }
 
     // Wyoming TCP server (default port 10300; set wyoming.port: 0 or WYOMING_PORT=0 to disable)
@@ -97,12 +119,14 @@ func configure(_ app: Application) async throws {
     else {
         wyomingPort = config.servers.wyoming.port
     }
+    let sttInfo: STTInfo = config.stt.engine == .qwen3 ? .qwen3 : .parakeet
     if wyomingPort > 0 && app.environment != .testing {
         let wyomingServer = WyomingServer(
             host: wyomingHost,
             port: wyomingPort,
             ttsService: app.ttsService,
             sttService: app.sttService,
+            sttInfo: sttInfo,
             logger: app.logger
         )
         app.lifecycle.use(wyomingServer)

--- a/Tests/speech-serverTests/Qwen3ConfigTests.swift
+++ b/Tests/speech-serverTests/Qwen3ConfigTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+import Yams
+
+@testable import speech_server
+
+final class Qwen3ConfigTests: XCTestCase {
+    // MARK: - Engine parsing
+
+    func testDefaultEngineIsParakeet() {
+        let config = ServerConfig()
+        XCTAssertEqual(config.stt.engine, .parakeet)
+    }
+
+    func testParseQwen3Engine() throws {
+        let yaml = "stt:\n  engine: qwen3\n"
+        let config = try YAMLDecoder().decode(ServerConfig.self, from: yaml)
+        XCTAssertEqual(config.stt.engine, .qwen3)
+    }
+
+    func testParakeetEngineStillParses() throws {
+        let yaml = "stt:\n  engine: parakeet\n"
+        let config = try YAMLDecoder().decode(ServerConfig.self, from: yaml)
+        XCTAssertEqual(config.stt.engine, .parakeet)
+    }
+
+    // MARK: - Qwen3STTSettings defaults
+
+    func testQwen3DefaultSettings() {
+        let settings = Qwen3STTSettings()
+        XCTAssertEqual(settings.variant, "int8")
+        XCTAssertNil(settings.language)
+    }
+
+    func testDefaultConfigHasNoQwen3Block() {
+        let config = ServerConfig()
+        XCTAssertNil(config.stt.qwen3)
+    }
+
+    // MARK: - Qwen3STTSettings YAML parsing
+
+    func testParseQwen3WithCustomVariant() throws {
+        let yaml = """
+            stt:
+              engine: qwen3
+              qwen3:
+                variant: f32
+            """
+        let config = try YAMLDecoder().decode(ServerConfig.self, from: yaml)
+        XCTAssertEqual(config.stt.engine, .qwen3)
+        XCTAssertEqual(config.stt.qwen3?.variant, "f32")
+        XCTAssertNil(config.stt.qwen3?.language)
+    }
+
+    func testParseQwen3WithLanguage() throws {
+        let yaml = """
+            stt:
+              engine: qwen3
+              qwen3:
+                language: en
+            """
+        let config = try YAMLDecoder().decode(ServerConfig.self, from: yaml)
+        XCTAssertEqual(config.stt.qwen3?.language, "en")
+        XCTAssertEqual(config.stt.qwen3?.variant, "int8")
+    }
+
+    func testParseQwen3WithAllSettings() throws {
+        let yaml = """
+            stt:
+              engine: qwen3
+              qwen3:
+                variant: f32
+                language: fr
+            """
+        let config = try YAMLDecoder().decode(ServerConfig.self, from: yaml)
+        XCTAssertEqual(config.stt.qwen3?.variant, "f32")
+        XCTAssertEqual(config.stt.qwen3?.language, "fr")
+    }
+
+    func testMinimalQwen3ConfigUsesDefaults() throws {
+        let yaml = "stt:\n  engine: qwen3\n"
+        let config = try YAMLDecoder().decode(ServerConfig.self, from: yaml)
+        let settings = config.stt.qwen3 ?? Qwen3STTSettings()
+        XCTAssertEqual(settings.variant, "int8")
+        XCTAssertNil(settings.language)
+    }
+
+    func testEmptyQwen3BlockUsesDefaults() throws {
+        let yaml = """
+            stt:
+              engine: qwen3
+              qwen3: {}
+            """
+        let config = try YAMLDecoder().decode(ServerConfig.self, from: yaml)
+        let settings = config.stt.qwen3 ?? Qwen3STTSettings()
+        XCTAssertEqual(settings.variant, "int8")
+        XCTAssertNil(settings.language)
+    }
+
+    // MARK: - Coexistence with Parakeet
+
+    func testParakeetBlockUnaffected() throws {
+        let yaml = """
+            stt:
+              engine: parakeet
+              parakeet:
+                model_version: v2
+            """
+        let config = try YAMLDecoder().decode(ServerConfig.self, from: yaml)
+        XCTAssertEqual(config.stt.engine, .parakeet)
+        XCTAssertEqual(config.stt.parakeet?.modelVersion, "v2")
+        XCTAssertNil(config.stt.qwen3)
+    }
+}

--- a/speech-server.yaml.example
+++ b/speech-server.yaml.example
@@ -20,10 +20,17 @@ servers:
     port: 10300           # TCP port for Wyoming protocol (Home Assistant). 0 = disabled; override with WYOMING_PORT env var.
 
 stt:
-  engine: parakeet      # Speech-to-text engine. Currently only: parakeet
+  engine: parakeet      # Speech-to-text engine: parakeet | qwen3
   parakeet:
     model_version: v3   # v3 = Parakeet TDT 0.6B v3, multilingual (25 langs, default)
                         # v2 = Parakeet TDT 0.6B v2, English-only (higher recall)
+
+  # Qwen3 ASR settings (only used when engine: qwen3)
+  # Uses FluidAudio's Qwen3AsrManager — encoder-decoder model with explicit language hinting.
+  # Requires macOS 15+.
+  # qwen3:
+  #   variant: int8     # int8 = quantized ~900 MB (default); f32 = full precision ~1.75 GB
+  #   language: en      # ISO 639-1 code (e.g. en, fr, de); omit for auto-detect
 
 tts:
   engine: pocket_tts    # Text-to-speech engine: pocket_tts | avspeech | kokoro


### PR DESCRIPTION
This is stacked on top of #20. 

Testing this locally, even the float version is very fast (smooth turn-by-turn on my Mac Studio) and seems to outperform Parakeet, which has a terrible time with my British accent.

---

Qwen3 is an encoder-decoder (Whisper-family) ASR model available in
FluidAudio that supports explicit language hints — unlike Parakeet which
auto-detects with no override. Setting `language: en` forces English
decoding, which can improve accuracy for non-American accents (e.g.
British English) by preventing the multilingual model from misinterpreting
accent features as other languages.

New files:
- Qwen3STTService.swift: wraps Qwen3AsrManager with VAD segmentation
- Qwen3ConfigTests.swift: YAML config parsing tests

Config: `stt.engine: qwen3` with optional `qwen3.variant` (int8/f32)
and `qwen3.language` (ISO 639-1 code). Requires macOS 15+.

Wyoming info response now uses STTInfo to dynamically advertise the
correct model name and language list based on the active STT engine.
