### PR TITLE
feat: support SSML input via AVSpeechUtterance(ssmlRepresentation:)

### DIFF
--- a/Sources/speech-server/Services/AVSpeechTTSService.swift
+++ b/Sources/speech-server/Services/AVSpeechTTSService.swift
@@ -75,7 +75,7 @@ final class AVSpeechTTSService: TTSService, Sendable {
         }
 
         var allSamples: [Float] = []
-        if text.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("<speak") {
+        if isSSML(text) {
             // SSML: don't split sentences, synthesise the whole block at once
             let samples = try await synthesizeFloatSamples(
                 text: text, voiceIdentifier: identifier)
@@ -111,7 +111,7 @@ final class AVSpeechTTSService: TTSService, Sendable {
         }
 
         let sentences: [String]
-        if text.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("<speak") {
+        if isSSML(text) {
             // SSML: don't split, synthesise as one block
             sentences = [text]
         }
@@ -141,6 +141,11 @@ final class AVSpeechTTSService: TTSService, Sendable {
 
     // MARK: - Private synthesis helpers
 
+    /// Detect whether input text is SSML (starts with <speak after trimming).
+    private func isSSML(_ text: String) -> Bool {
+        text.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("<speak")
+    }
+
     /// Synthesises one utterance and returns the concatenated Float32 samples.
     ///
     /// `write(_:toBufferCallback:)` is asynchronous: it returns immediately and delivers
@@ -168,52 +173,33 @@ final class AVSpeechTTSService: TTSService, Sendable {
             (continuation: CheckedContinuation<[Float], Error>) in
             let synthesizer = AVSpeechSynthesizer()
 
-            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmed.hasPrefix("<speak") {
-                // SSML mode
-                guard let utterance = AVSpeechUtterance(ssmlRepresentation: text) else {
+            let utterance: AVSpeechUtterance
+            if isSSML(text) {
+                guard let u = AVSpeechUtterance(ssmlRepresentation: text) else {
                     continuation.resume(throwing: AVSpeechTTSError.invalidSSML)
                     return
                 }
-                utterance.voice = AVSpeechSynthesisVoice(identifier: voiceIdentifier)
-
-                synthesizer.write(utterance) { [synthesizer] buffer in
-                    _ = synthesizer
-                    guard let pcmBuffer = buffer as? AVAudioPCMBuffer else { return }
-                    if pcmBuffer.frameLength == 0 {
-                        if !bridge.resumed {
-                            bridge.resumed = true
-                            continuation.resume(returning: bridge.samples)
-                        }
-                        return
-                    }
-                    if let channelData = pcmBuffer.floatChannelData {
-                        let count = Int(pcmBuffer.frameLength)
-                        bridge.samples.append(
-                            contentsOf: UnsafeBufferPointer(start: channelData[0], count: count))
-                    }
-                }
+                utterance = u
             }
             else {
-                // Plain text mode
-                let utterance = AVSpeechUtterance(string: text)
-                utterance.voice = AVSpeechSynthesisVoice(identifier: voiceIdentifier)
+                utterance = AVSpeechUtterance(string: text)
+            }
+            utterance.voice = AVSpeechSynthesisVoice(identifier: voiceIdentifier)
 
-                synthesizer.write(utterance) { [synthesizer] buffer in
-                    _ = synthesizer
-                    guard let pcmBuffer = buffer as? AVAudioPCMBuffer else { return }
-                    if pcmBuffer.frameLength == 0 {
-                        if !bridge.resumed {
-                            bridge.resumed = true
-                            continuation.resume(returning: bridge.samples)
-                        }
-                        return
+            synthesizer.write(utterance) { [synthesizer] buffer in
+                _ = synthesizer
+                guard let pcmBuffer = buffer as? AVAudioPCMBuffer else { return }
+                if pcmBuffer.frameLength == 0 {
+                    if !bridge.resumed {
+                        bridge.resumed = true
+                        continuation.resume(returning: bridge.samples)
                     }
-                    if let channelData = pcmBuffer.floatChannelData {
-                        let count = Int(pcmBuffer.frameLength)
-                        bridge.samples.append(
-                            contentsOf: UnsafeBufferPointer(start: channelData[0], count: count))
-                    }
+                    return
+                }
+                if let channelData = pcmBuffer.floatChannelData {
+                    let count = Int(pcmBuffer.frameLength)
+                    bridge.samples.append(
+                        contentsOf: UnsafeBufferPointer(start: channelData[0], count: count))
                 }
             }
         }

--- a/Sources/speech-server/Services/AVSpeechTTSService.swift
+++ b/Sources/speech-server/Services/AVSpeechTTSService.swift
@@ -75,10 +75,18 @@ final class AVSpeechTTSService: TTSService, Sendable {
         }
 
         var allSamples: [Float] = []
-        for sentence in splitSentences(text) {
+        if text.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("<speak") {
+            // SSML: don't split sentences, synthesise the whole block at once
             let samples = try await synthesizeFloatSamples(
-                text: sentence, voiceIdentifier: identifier)
+                text: text, voiceIdentifier: identifier)
             allSamples.append(contentsOf: samples)
+        }
+        else {
+            for sentence in splitSentences(text) {
+                let samples = try await synthesizeFloatSamples(
+                    text: sentence, voiceIdentifier: identifier)
+                allSamples.append(contentsOf: samples)
+            }
         }
 
         if allSamples.isEmpty {
@@ -102,7 +110,14 @@ final class AVSpeechTTSService: TTSService, Sendable {
             }
         }
 
-        let sentences = splitSentences(text)
+        let sentences: [String]
+        if text.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("<speak") {
+            // SSML: don't split, synthesise as one block
+            sentences = [text]
+        }
+        else {
+            sentences = splitSentences(text)
+        }
         logger.notice("AVSpeech synthesizeStream: \(sentences.count) sentence(s)")
 
         return AsyncThrowingStream { continuation in
@@ -131,6 +146,9 @@ final class AVSpeechTTSService: TTSService, Sendable {
     /// `write(_:toBufferCallback:)` is asynchronous: it returns immediately and delivers
     /// audio buffers on a background thread. The continuation is resumed from the
     /// zero-length buffer callback, which fires when synthesis is complete.
+    ///
+    /// If the text starts with `<speak` it is treated as SSML (via
+    /// `AVSpeechUtterance(ssmlRepresentation:)`), otherwise as plain text.
     private func synthesizeFloatSamples(
         text: String, voiceIdentifier: String
     ) async throws
@@ -149,27 +167,53 @@ final class AVSpeechTTSService: TTSService, Sendable {
         return try await withCheckedThrowingContinuation {
             (continuation: CheckedContinuation<[Float], Error>) in
             let synthesizer = AVSpeechSynthesizer()
-            let utterance = AVSpeechUtterance(string: text)
-            utterance.voice = AVSpeechSynthesisVoice(identifier: voiceIdentifier)
 
-            // write() returns immediately; callbacks fire asynchronously.
-            // The closure captures `synthesizer` to keep it alive until synthesis completes.
-            synthesizer.write(utterance) { [synthesizer] buffer in
-                _ = synthesizer  // retain until this callback fires
-                guard let pcmBuffer = buffer as? AVAudioPCMBuffer else { return }
-                if pcmBuffer.frameLength == 0 {
-                    // Zero-length buffer signals end of utterance.
-                    // Guard against double-resume in case multiple zero-length buffers arrive.
-                    if !bridge.resumed {
-                        bridge.resumed = true
-                        continuation.resume(returning: bridge.samples)
-                    }
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.hasPrefix("<speak") {
+                // SSML mode
+                guard let utterance = AVSpeechUtterance(ssmlRepresentation: text) else {
+                    continuation.resume(throwing: AVSpeechTTSError.invalidSSML)
                     return
                 }
-                if let channelData = pcmBuffer.floatChannelData {
-                    let count = Int(pcmBuffer.frameLength)
-                    bridge.samples.append(
-                        contentsOf: UnsafeBufferPointer(start: channelData[0], count: count))
+                utterance.voice = AVSpeechSynthesisVoice(identifier: voiceIdentifier)
+
+                synthesizer.write(utterance) { [synthesizer] buffer in
+                    _ = synthesizer
+                    guard let pcmBuffer = buffer as? AVAudioPCMBuffer else { return }
+                    if pcmBuffer.frameLength == 0 {
+                        if !bridge.resumed {
+                            bridge.resumed = true
+                            continuation.resume(returning: bridge.samples)
+                        }
+                        return
+                    }
+                    if let channelData = pcmBuffer.floatChannelData {
+                        let count = Int(pcmBuffer.frameLength)
+                        bridge.samples.append(
+                            contentsOf: UnsafeBufferPointer(start: channelData[0], count: count))
+                    }
+                }
+            }
+            else {
+                // Plain text mode
+                let utterance = AVSpeechUtterance(string: text)
+                utterance.voice = AVSpeechSynthesisVoice(identifier: voiceIdentifier)
+
+                synthesizer.write(utterance) { [synthesizer] buffer in
+                    _ = synthesizer
+                    guard let pcmBuffer = buffer as? AVAudioPCMBuffer else { return }
+                    if pcmBuffer.frameLength == 0 {
+                        if !bridge.resumed {
+                            bridge.resumed = true
+                            continuation.resume(returning: bridge.samples)
+                        }
+                        return
+                    }
+                    if let channelData = pcmBuffer.floatChannelData {
+                        let count = Int(pcmBuffer.frameLength)
+                        bridge.samples.append(
+                            contentsOf: UnsafeBufferPointer(start: channelData[0], count: count))
+                    }
                 }
             }
         }
@@ -181,6 +225,7 @@ final class AVSpeechTTSService: TTSService, Sendable {
 enum AVSpeechTTSError: Error, CustomStringConvertible {
     case voiceNotFound(String)
     case noAudioProduced
+    case invalidSSML
 
     var description: String {
         switch self {
@@ -188,6 +233,8 @@ enum AVSpeechTTSError: Error, CustomStringConvertible {
             return "Voice '\(voice)' is not available. Use a system voice name (e.g. 'Samantha') or full identifier."
         case .noAudioProduced:
             return "AVSpeechSynthesizer produced no audio for the given input."
+        case .invalidSSML:
+            return "SSML input could not be parsed."
         }
     }
 }

--- a/Sources/speech-server/Services/AVSpeechTTSService.swift
+++ b/Sources/speech-server/Services/AVSpeechTTSService.swift
@@ -99,6 +99,11 @@ final class AVSpeechTTSService: TTSService, Sendable {
 
     /// Streams Int16 LE PCM (no WAV header), one chunk per sentence.
     ///
+    /// Plain text is split into sentences and yields one PCM chunk per sentence.
+    /// SSML input (`<speak>…`) is never split: the whole block is synthesised as a
+    /// single utterance and yields exactly one chunk, regardless of how many
+    /// sentences it contains.
+    ///
     /// All Float32 samples for a sentence are accumulated first, then converted
     /// with a single peak-normalisation pass. Per-buffer normalisation is avoided
     /// because AVSpeech often delivers a quiet tail buffer whose near-zero peak
@@ -141,9 +146,17 @@ final class AVSpeechTTSService: TTSService, Sendable {
 
     // MARK: - Private synthesis helpers
 
-    /// Detect whether input text is SSML (starts with <speak after trimming).
+    /// Detect whether input text is SSML.
+    ///
+    /// The trimmed text must start with the `<speak>` root element: either a bare
+    /// `<speak>` or `<speak ` with attributes. Similar tags whose names merely
+    /// begin with "speak" (e.g. `<speaker>`) are deliberately not treated as SSML
+    /// and are synthesised as plain text instead.
     private func isSSML(_ text: String) -> Bool {
-        text.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("<speak")
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("<speak") else { return false }
+        let remainder = trimmed.dropFirst("<speak".count)
+        return remainder.first == ">" || remainder.first?.isWhitespace == true
     }
 
     /// Synthesises one utterance and returns the concatenated Float32 samples.
@@ -175,7 +188,10 @@ final class AVSpeechTTSService: TTSService, Sendable {
 
             let utterance: AVSpeechUtterance
             if isSSML(text) {
-                guard let u = AVSpeechUtterance(ssmlRepresentation: text) else {
+                // Use the trimmed string: isSSML detected on the trimmed text, and
+                // leading whitespace would make ssmlRepresentation parsing fail.
+                let ssml = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard let u = AVSpeechUtterance(ssmlRepresentation: ssml) else {
                     continuation.resume(throwing: AVSpeechTTSError.invalidSSML)
                     return
                 }

--- a/Tests/speech-serverTests/AVSpeechTTSServiceTests.swift
+++ b/Tests/speech-serverTests/AVSpeechTTSServiceTests.swift
@@ -154,4 +154,77 @@ final class AVSpeechTTSServiceTests: XCTestCase {
         let data = try await service.synthesize(text: "Hi.", voice: avVoice.identifier)
         XCTAssertGreaterThan(data.count, 44)
     }
+
+    // MARK: - SSML
+
+    func testSSMLDetectionSynthesize() async throws {
+        let plainText = try await service.synthesize(text: "Hello.", voice: service.defaultVoice)
+        let ssmlText = try await service.synthesize(text: "<speak>Hello</speak>", voice: service.defaultVoice)
+
+        XCTAssertEqual(plainText.prefix(4), Data("RIFF".utf8))
+        XCTAssertEqual(ssmlText.prefix(4), Data("RIFF".utf8))
+        XCTAssertGreaterThan(ssmlText.count, 44)
+    }
+
+    func testSSMLWithBreakTag() async throws {
+        let data = try await service.synthesize(
+            text: "<speak>Hello<break time=\"500ms\"/>world</speak>",
+            voice: service.defaultVoice
+        )
+        XCTAssertEqual(data.prefix(4), Data("RIFF".utf8))
+        XCTAssertGreaterThan(data.count, 44)
+    }
+
+    func testSSMLWithPhoneme() async throws {
+        let data = try await service.synthesize(
+            text: "<speak>My name is <phoneme alphabet=\"ipac\" ph=\"ˈænə\">Anna</phoneme></speak>",
+            voice: service.defaultVoice
+        )
+        XCTAssertEqual(data.prefix(4), Data("RIFF".utf8))
+        XCTAssertGreaterThan(data.count, 44)
+    }
+
+    func testSSMLWithoutSpeakTagUsesPlainText() async throws {
+        let data = try await service.synthesize(
+            text: "<notspeak>Hello</notspeak>",
+            voice: service.defaultVoice
+        )
+        XCTAssertEqual(data.prefix(4), Data("RIFF".utf8))
+        XCTAssertGreaterThan(data.count, 44)
+    }
+
+    func testSSMLStreamDetection() async throws {
+        let stream = service.synthesizeStream(
+            text: "<speak>Hello world</speak>",
+            voice: service.defaultVoice
+        )
+        var chunkCount = 0
+        for try await chunk in stream {
+            XCTAssertFalse(chunk.isEmpty)
+            XCTAssertEqual(chunk.count % 2, 0)
+            chunkCount += 1
+        }
+        XCTAssertGreaterThan(chunkCount, 0, "SSML stream must yield at least one PCM chunk")
+    }
+
+    func testInvalidSSMLThrowsError() async {
+        do {
+            _ = try await service.synthesize(
+                text: "<speak>Unclosed tag",
+                voice: service.defaultVoice
+            )
+            XCTFail("Expected invalidSSML error")
+        }
+        catch let error as AVSpeechTTSError {
+            if case .invalidSSML = error {
+                // expected
+            }
+            else {
+                XCTFail("Unexpected AVSpeechTTSError: \(error)")
+            }
+        }
+        catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
 }

--- a/Tests/speech-serverTests/AVSpeechTTSServiceTests.swift
+++ b/Tests/speech-serverTests/AVSpeechTTSServiceTests.swift
@@ -193,6 +193,28 @@ final class AVSpeechTTSServiceTests: XCTestCase {
         XCTAssertGreaterThan(data.count, 44)
     }
 
+    func testSpeakerTagIsNotSSML() async throws {
+        // "<speaker>" shares the "<speak" prefix but is not SSML; it must go
+        // through the plain-text path instead of throwing invalidSSML.
+        let data = try await service.synthesize(
+            text: "<speaker>Hello</speaker>",
+            voice: service.defaultVoice
+        )
+        XCTAssertEqual(data.prefix(4), Data("RIFF".utf8))
+        XCTAssertGreaterThan(data.count, 44)
+    }
+
+    func testSSMLWithLeadingWhitespace() async throws {
+        // Detection trims whitespace, so the SSML parser must receive the
+        // trimmed string — otherwise leading whitespace causes a parse error.
+        let data = try await service.synthesize(
+            text: "\n  <speak>Hello</speak>",
+            voice: service.defaultVoice
+        )
+        XCTAssertEqual(data.prefix(4), Data("RIFF".utf8))
+        XCTAssertGreaterThan(data.count, 44)
+    }
+
     func testSSMLStreamDetection() async throws {
         let stream = service.synthesizeStream(
             text: "<speak>Hello world</speak>",


### PR DESCRIPTION
## Summary

Detect when input text starts with `<speak>` and use the SSML-aware initializer `AVSpeechUtterance(ssmlRepresentation:)` instead of `AVSpeechUtterance(string:)`. This enables phoneme replacement, pauses, emphasis, prosody, volume, pitch, and say-as support on macOS 14+.

Plain text input continues to work unchanged.

## Changes

- **AVSpeechTTSService.swift**: Added `isSSML(_:)` helper centralizing SSML detection across all three entry points (`synthesize`, `synthesizeStream`, `synthesizeFloatSamples`). When input starts with `<speak`, sentences are not split and `AVSpeechUtterance(ssmlRepresentation:)` is used.

Round-2 review fixes (20aae6b):
- `isSSML` requires the `<speak>` root element (bare tag or tag with attributes) — `<speaker>` and similar prefixes are no longer misrouted into the SSML path
- The trimmed string is passed to `AVSpeechUtterance(ssmlRepresentation:)`, so leading whitespace no longer causes a spurious `invalidSSML` error
- `synthesizeStream` documentation now states SSML blocks yield exactly one chunk

## Testing

- 8 regression tests covering SSML synthesis, break tags, phonemes, non-speak XML fallback, `<speaker>` fallback, leading-whitespace SSML, streaming, and invalid SSML error handling.

## Compatibility

- Requires macOS 14+ (AVSpeechUtterance(ssmlRepresentation:) availability)
- No dependency changes
- Backward compatible — plain text path unchanged